### PR TITLE
Refactor ops to use explicit operands

### DIFF
--- a/TestApp/TestApp.cpp
+++ b/TestApp/TestApp.cpp
@@ -6,22 +6,20 @@ int main(int Argc, char* Argv[])
 {
     ConVariableCached X;
     ConVariableCached Y;
-    ConVariableCached Z;
-    ConVariableAbsolute Five(5);
-    ConVariableAbsolute Ten(10);
-    ConThread Thread({&X,&Y});
-    ConSetOp Set_X_10({&X, &Ten});
-    ConSetOp Set_Y_10({&Y, &Ten});
-    ConAddOp AddYToX({&X, &Y});
-    ConSubOp Sub5FromY({&Y, &Five});
-    ConSwpOp SwpX({&X});
+    vector<ConVariable*> regs = {&X, &Y};
+    ConThread Thread(regs);
+    ConSetOp Set_X_10({{OperandKind::Reg, 0}, {OperandKind::Imm, 10}});
+    ConSetOp Set_Y_10({{OperandKind::Reg, 1}, {OperandKind::Imm, 10}});
+    ConAddOp AddYToX({{OperandKind::Reg, 0}, {OperandKind::Reg, 0}, {OperandKind::Reg, 1}});
+    ConSubOp Sub5FromY({{OperandKind::Reg, 1}, {OperandKind::Reg, 1}, {OperandKind::Imm, 5}});
+    ConSwpOp SwpX({{OperandKind::Reg, 0}});
     Thread.ConstructLine({&Set_X_10});
     Thread.ConstructLine({&Set_Y_10});
     Thread.ConstructLine({&AddYToX});
     Thread.ConstructLine({&Sub5FromY});
     Thread.ConstructLine({&AddYToX});
     Thread.ConstructLine({&SwpX});
-    Thread.Execute();
+    Thread.Execute(regs);
     
     return 0;
 }

--- a/src/Conchpiler/compilable.h
+++ b/src/Conchpiler/compilable.h
@@ -1,10 +1,11 @@
 #pragma once
 #include "common.h"
+#include "variable.h"
 
 struct ConCompilable 
 {
     virtual ~ConCompilable() = default;
-    virtual void Execute() = 0;
+    virtual void Execute(vector<ConVariable*>& regs) = 0;
     virtual void UpdateCycleCount() { ResetCycleCount(); };
     
     void AddCycles(int32 int32);

--- a/src/Conchpiler/line.cpp
+++ b/src/Conchpiler/line.cpp
@@ -4,11 +4,11 @@ ConLine::~ConLine()
 {
 }
 
-void ConLine::Execute()
+void ConLine::Execute(vector<ConVariable*>& regs)
 {
     for (ConBaseOp* Op : Ops)
     {
-        Op->Execute();
+        Op->Execute(regs);
     }
 }
 

--- a/src/Conchpiler/line.h
+++ b/src/Conchpiler/line.h
@@ -8,7 +8,7 @@ struct ConLine : public ConCompilable
 public:
 
     virtual  ~ConLine() override;
-    virtual void Execute() override;
+    virtual void Execute(vector<ConVariable*>& regs) override;
     virtual void UpdateCycleCount() override;
     void SetOps(const vector<ConBaseOp*>& Ops);
 

--- a/src/Conchpiler/thread.cpp
+++ b/src/Conchpiler/thread.cpp
@@ -2,13 +2,14 @@
 #include "thread.h"
 #include <iostream>
 #include <ostream>
-void ConThread::Execute()
+void ConThread::Execute(vector<ConVariable*>& regs)
 {
     assert(Lines.size() > 0);
+    Variables = regs;
     for (ConLine& Line : Lines)
     {
-        Line.Execute();
-        for (const ConVariable* Var : Variables)
+        Line.Execute(regs);
+        for (const ConVariable* Var : regs)
         {
             const ConVariableCached* Cached = dynamic_cast<const ConVariableCached*>(Var);
             cout << Cached->GetVal() << ", (" << Cached->GetCache() << ") ";

--- a/src/Conchpiler/thread.h
+++ b/src/Conchpiler/thread.h
@@ -7,9 +7,10 @@ struct ConThread final : public ConCompilable
 public:
     ConThread(): Variables() {}
     explicit ConThread(const vector<ConVariable*> &InVariables) : Variables(InVariables) {}
-    virtual void Execute() override;
+    virtual void Execute(vector<ConVariable*>& regs) override;
     virtual void UpdateCycleCount() override;
     void SetVariables(const vector<ConVariable*>& InVariables);
+    const vector<ConVariable*>& GetVariables() const { return Variables; }
     void ConstructLine(const vector<ConBaseOp*>& Ops);
     
 private:

--- a/src/Conchpiler/variable.cpp
+++ b/src/Conchpiler/variable.cpp
@@ -1,15 +1,5 @@
 #include "variable.h"
 
-int32 ConVariableAbsolute::GetVal() const
-{
-    return Val;
-}
-
-void ConVariableAbsolute::SetVal(const int32 NewVal)
-{
-    Val = NewVal;   
-}
-
 int32 ConVariableCached::GetVal() const
 {
     return Val;

--- a/src/Conchpiler/variable.h
+++ b/src/Conchpiler/variable.h
@@ -9,17 +9,6 @@ struct ConVariable
     virtual void SetVal(int32 NewVal) = 0;
 };
 
-struct ConVariableAbsolute : public ConVariable
-{
-    ConVariableAbsolute() = default;
-    ConVariableAbsolute(const int32 InVal)
-        : Val(InVal)  {}
-    virtual int32 GetVal() const override;
-    virtual void SetVal(int32 NewVal) override;
-private:
-    int32 Val = 0;
-};
-
 struct ConVariableCached : public ConVariable
 {
     virtual int32 GetVal() const override;


### PR DESCRIPTION
## Summary
- introduce Operand/OperandKind and helper to read from registers or immediates
- rewrite operations to use operand vectors and register file
- remove ConVariableAbsolute and update test application

## Testing
- `g++ -std=c++17 TestApp/TestApp.cpp src/Conchpiler/*.cpp -o testapp && ./testapp`

------
https://chatgpt.com/codex/tasks/task_e_68c708951d64832d9242dd4c0022cadb