### PR TITLE
Add basic parser and cycle counting

### DIFF
--- a/TestApp/TestApp.cpp
+++ b/TestApp/TestApp.cpp
@@ -1,27 +1,22 @@
-#include "../src/Conchpiler/thread.h"
+#include "../src/Conchpiler/parser.h"
+#include <iostream>
+#include <string>
 #include <vector>
-struct ConBaseOp;
 
 int main(int Argc, char* Argv[])
 {
-    ConVariableCached X;
-    ConVariableCached Y;
-    ConVariableCached Z;
-    ConVariableAbsolute Five(5);
-    ConVariableAbsolute Ten(10);
-    ConThread Thread({&X,&Y});
-    ConSetOp Set_X_10({&X, &Ten});
-    ConSetOp Set_Y_10({&Y, &Ten});
-    ConAddOp AddYToX({&X, &Y});
-    ConSubOp Sub5FromY({&Y, &Five});
-    ConSwpOp SwpX({&X});
-    Thread.ConstructLine({&Set_X_10});
-    Thread.ConstructLine({&Set_Y_10});
-    Thread.ConstructLine({&AddYToX});
-    Thread.ConstructLine({&Sub5FromY});
-    Thread.ConstructLine({&AddYToX});
-    Thread.ConstructLine({&SwpX});
+    ConParser Parser;
+    std::vector<std::string> Lines = {
+        "SET X 10",
+        "SET Y 10",
+        "ADD X Y",
+        "SUB Y 5",
+        "ADD X Y",
+        "SWP X"
+    };
+    ConThread Thread = Parser.Parse(Lines);
+    Thread.UpdateCycleCount();
     Thread.Execute();
-    
+    std::cout << "Total cycles: " << Thread.GetCycleCount() << std::endl;
     return 0;
 }

--- a/src/Conchpiler/line.cpp
+++ b/src/Conchpiler/line.cpp
@@ -18,7 +18,8 @@ void ConLine::UpdateCycleCount()
     for (ConBaseOp* Op : Ops)
     {
         Op->UpdateCycleCount();
-    }   
+        AddCycles(Op->GetCycleCount());
+    }
 }
 
 void ConLine::SetOps(const vector<ConBaseOp*>& Ops)

--- a/src/Conchpiler/op.cpp
+++ b/src/Conchpiler/op.cpp
@@ -17,6 +17,12 @@ const vector<ConVariable*> &ConBaseOp::GetArgs() const
     return Args;
 }
 
+void ConBaseOp::UpdateCycleCount()
+{
+    ConCompilable::UpdateCycleCount();
+    AddCycles(GetBaseCycleCost());
+}
+
 
 ConVariable* ConContextualReturnOp::GetDstArg() const
 {
@@ -48,7 +54,14 @@ void ConMulOp::Execute()
 void ConSubOp::Execute()
 {
     const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() - SrcArg.at(1)->GetVal()); 
+    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() - SrcArg.at(1)->GetVal());
+}
+
+void ConDivOp::Execute()
+{
+    const vector<const ConVariable*> SrcArg = GetSrcArg();
+    const int32 B = SrcArg.at(1)->GetVal();
+    GetDstArg()->SetVal(B == 0 ? 0 : SrcArg.at(0)->GetVal() / B);
 }
 
 void ConSetOp::Execute()

--- a/src/Conchpiler/op.h
+++ b/src/Conchpiler/op.h
@@ -15,6 +15,9 @@ struct ConBaseOp : public ConCompilable
     const vector<ConVariable*> &GetArgs() const;
     int32 GetArgsCount() const { return int32(GetArgs().size()); }
 
+    virtual void UpdateCycleCount() override;
+    virtual int32 GetBaseCycleCost() const { return 1; }
+
     template<typename T>
     T GetArgAs(int32 Index);
 
@@ -52,6 +55,12 @@ struct ConMulOp final : public ConContextualReturnOp
 };
 
 struct ConSubOp final : public ConContextualReturnOp
+{
+    using ConContextualReturnOp::ConContextualReturnOp;
+    virtual void Execute() override;
+};
+
+struct ConDivOp final : public ConContextualReturnOp
 {
     using ConContextualReturnOp::ConContextualReturnOp;
     virtual void Execute() override;

--- a/src/Conchpiler/parser.cpp
+++ b/src/Conchpiler/parser.cpp
@@ -1,0 +1,102 @@
+#include "parser.h"
+#include <sstream>
+
+ConParser::ConParser()
+{
+    VarStorage.emplace_back(std::make_unique<ConVariableCached>());
+    VarMap["X"] = VarStorage.back().get();
+    VarStorage.emplace_back(std::make_unique<ConVariableCached>());
+    VarMap["Y"] = VarStorage.back().get();
+    VarStorage.emplace_back(std::make_unique<ConVariableCached>());
+    VarMap["Z"] = VarStorage.back().get();
+}
+
+ConVariable* ConParser::ResolveToken(const std::string& Tok)
+{
+    auto It = VarMap.find(Tok);
+    if (It != VarMap.end())
+    {
+        return It->second;
+    }
+    int32 Val = std::stoi(Tok);
+    ConstStorage.emplace_back(std::make_unique<ConVariableAbsolute>(Val));
+    return ConstStorage.back().get();
+}
+
+std::vector<ConBaseOp*> ConParser::ParseTokens(const std::vector<std::string>& Tokens)
+{
+    std::vector<ConBaseOp*> Ops;
+    std::vector<ConVariable*> Stack;
+
+    for (auto It = Tokens.rbegin(); It != Tokens.rend(); ++It)
+    {
+        const std::string& Tok = *It;
+        if (Tok == "SET")
+        {
+            ConVariable* Dst = Stack.back(); Stack.pop_back();
+            ConVariable* Src = Stack.back(); Stack.pop_back();
+            OpStorage.emplace_back(std::make_unique<ConSetOp>(std::vector<ConVariable*>{Dst, Src}));
+            Ops.push_back(OpStorage.back().get());
+            Stack.push_back(Dst);
+        }
+        else if (Tok == "SWP")
+        {
+            ConVariable* Var = Stack.back(); Stack.pop_back();
+            OpStorage.emplace_back(std::make_unique<ConSwpOp>(std::vector<ConVariable*>{Var}));
+            Ops.push_back(OpStorage.back().get());
+            Stack.push_back(Var);
+        }
+        else if (Tok == "ADD" || Tok == "SUB" || Tok == "MULT" || Tok == "DIVI")
+        {
+            ConVariable* Dst = Stack.back(); Stack.pop_back();
+            ConVariable* Src = Stack.back(); Stack.pop_back();
+            if (Tok == "ADD")
+            {
+                OpStorage.emplace_back(std::make_unique<ConAddOp>(std::vector<ConVariable*>{Dst, Src}));
+            }
+            else if (Tok == "SUB")
+            {
+                OpStorage.emplace_back(std::make_unique<ConSubOp>(std::vector<ConVariable*>{Dst, Src}));
+            }
+            else if (Tok == "MULT")
+            {
+                OpStorage.emplace_back(std::make_unique<ConMulOp>(std::vector<ConVariable*>{Dst, Src}));
+            }
+            else
+            {
+                OpStorage.emplace_back(std::make_unique<ConDivOp>(std::vector<ConVariable*>{Dst, Src}));
+            }
+            Ops.push_back(OpStorage.back().get());
+            Stack.push_back(Dst);
+        }
+        else
+        {
+            Stack.push_back(ResolveToken(Tok));
+        }
+    }
+
+    return Ops;
+}
+
+ConThread ConParser::Parse(const std::vector<std::string>& Lines)
+{
+    std::vector<ConVariable*> Vars;
+    for (auto& V : VarStorage)
+    {
+        Vars.push_back(V.get());
+    }
+    ConThread Thread(Vars);
+    for (const std::string& Line : Lines)
+    {
+        std::stringstream SS(Line);
+        std::vector<std::string> Tokens;
+        std::string Tok;
+        while (SS >> Tok)
+        {
+            Tokens.push_back(Tok);
+        }
+        Thread.ConstructLine(ParseTokens(Tokens));
+    }
+    return Thread;
+}
+

--- a/src/Conchpiler/parser.h
+++ b/src/Conchpiler/parser.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "thread.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct ConParser
+{
+    ConParser();
+
+    ConThread Parse(const vector<string>& Lines);
+
+private:
+    std::vector<std::unique_ptr<ConVariableCached>> VarStorage;
+    std::vector<std::unique_ptr<ConVariableAbsolute>> ConstStorage;
+    std::vector<std::unique_ptr<ConBaseOp>> OpStorage;
+    std::unordered_map<std::string, ConVariableCached*> VarMap;
+
+    ConVariable* ResolveToken(const std::string& Tok);
+    std::vector<ConBaseOp*> ParseTokens(const std::vector<std::string>& Tokens);
+};
+

--- a/src/Conchpiler/thread.cpp
+++ b/src/Conchpiler/thread.cpp
@@ -20,9 +20,11 @@ void ConThread::Execute()
 void ConThread::UpdateCycleCount()
 {
     ConCompilable::UpdateCycleCount();
+    const int32 VarCount = int32(Variables.size());
     for (ConLine& Line : Lines)
     {
         Line.UpdateCycleCount();
+        Line.AddCycles(VarCount);
         AddCycles(Line.GetCycleCount());
     }
 }


### PR DESCRIPTION
## Summary
- Implement parser translating Cosmic Tinkerer syntax into executable ops
- Add division op and per-op cycle tracking
- Accumulate cycle counts per line and thread
- Update sample TestApp to use parser and display total cycles

## Testing
- `g++ -std=c++17 TestApp/TestApp.cpp src/Conchpiler/*.cpp -Isrc/Conchpiler -o conch_test`
- `./conch_test`

------
https://chatgpt.com/codex/tasks/task_e_68c795068680832d9e7d399528e193f6