### PR TITLE
Add support for equality and negated IF conditions

### DIFF
--- a/src/Conchpiler/line.cpp
+++ b/src/Conchpiler/line.cpp
@@ -27,23 +27,32 @@ void ConLine::SetOps(const vector<ConBaseOp*>& Ops)
     this->Ops = Ops;
 }
 
-void ConLine::SetCondition(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount)
+void ConLine::SetCondition(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount, bool bInvert)
 {
     Condition = Op;
     Left = Lhs;
     Right = Rhs;
     Skip = SkipCount;
+    Invert = bInvert;
 }
 
 bool ConLine::EvaluateCondition() const
 {
+    bool Result = true;
     switch (Condition)
     {
-    case ConConditionOp::GTR:
-        return Left->GetVal() > Right->GetVal();
-    case ConConditionOp::LSR:
-        return Left->GetVal() < Right->GetVal();
+    case ConConditionOp::GRTR:
+        Result = Left->GetVal() > Right->GetVal();
+        break;
+    case ConConditionOp::LSSR:
+        Result = Left->GetVal() < Right->GetVal();
+        break;
+    case ConConditionOp::EQL:
+        Result = Left->GetVal() == Right->GetVal();
+        break;
     default:
-        return true;
+        Result = true;
+        break;
     }
+    return Invert ? !Result : Result;
 }

--- a/src/Conchpiler/line.h
+++ b/src/Conchpiler/line.h
@@ -7,8 +7,9 @@
 enum class ConConditionOp
 {
     None,
-    GTR,
-    LSR
+    GRTR,
+    LSSR,
+    EQL
 };
 
 struct ConLine : public ConCompilable
@@ -19,7 +20,7 @@ public:
     virtual void Execute() override;
     virtual void UpdateCycleCount() override;
     void SetOps(const vector<ConBaseOp*>& Ops);
-    void SetCondition(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount);
+    void SetCondition(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount, bool bInvert);
     bool IsConditional() const { return Condition != ConConditionOp::None; }
     bool EvaluateCondition() const;
     int32 GetSkipCount() const { return Skip; }
@@ -31,5 +32,6 @@ private:
     ConVariable* Left = nullptr;
     ConVariable* Right = nullptr;
     int32 Skip = 0;
+    bool Invert = false;
 };
 

--- a/src/Conchpiler/parser.cpp
+++ b/src/Conchpiler/parser.cpp
@@ -116,6 +116,7 @@ struct ParsedLine
     ConVariable* Lhs = nullptr;
     ConVariable* Rhs = nullptr;
     int32 SkipCount = 0;
+    bool Invert = false;
     std::vector<ConBaseOp*> Ops;
 };
 
@@ -139,16 +140,21 @@ ConThread ConParser::Parse(const std::vector<std::string>& Lines)
         {
             Tokens.push_back(Tok);
         }
-        if (!Tokens.empty() && Tokens[0] == "IF")
+        if (!Tokens.empty() && (Tokens[0] == "IF" || Tokens[0] == "IFN"))
         {
             P.IsIf = true;
-            if (Tokens[1] == "GTR")
+            P.Invert = Tokens[0] == "IFN";
+            if (Tokens[1] == "GRTR" || Tokens[1] == "GTR")
             {
-                P.Cmp = ConConditionOp::GTR;
+                P.Cmp = ConConditionOp::GRTR;
+            }
+            else if (Tokens[1] == "LSSR" || Tokens[1] == "LSR")
+            {
+                P.Cmp = ConConditionOp::LSSR;
             }
             else
             {
-                P.Cmp = ConConditionOp::LSR;
+                P.Cmp = ConConditionOp::EQL;
             }
             P.Lhs = ResolveToken(Tokens[2]);
             P.Rhs = ResolveToken(Tokens[3]);
@@ -193,7 +199,7 @@ ConThread ConParser::Parse(const std::vector<std::string>& Lines)
         Line.SetOps(P.Ops);
         if (P.IsIf)
         {
-            Line.SetCondition(P.Cmp, P.Lhs, P.Rhs, P.SkipCount);
+            Line.SetCondition(P.Cmp, P.Lhs, P.Rhs, P.SkipCount, P.Invert);
         }
         Thread.ConstructLine(Line);
     }


### PR DESCRIPTION
## Summary
- extend `ConConditionOp` with `EQL` and rename tokens to `GRTR`/`LSSR`
- allow `ConParser` to parse `IF` and `IFN` using GRTR/LSSR/EQL
- handle GRTR/LSSR/EQL with optional inversion in `ConLine::EvaluateCondition`

## Testing
- `g++ -std=c++17 TestApp/TestApp.cpp src/Conchpiler/*.cpp -o testapp && ./testapp`
- `g++ -std=c++17 /tmp/test_conditions.cpp src/Conchpiler/*.cpp -I. -o test_conditions && ./test_conditions`


------
https://chatgpt.com/codex/tasks/task_e_68c7aa093f70832db29e471a5c7bdc53