### PR TITLE
Fix SET operation with constant sources

### DIFF
--- a/src/Conchpiler/op.cpp
+++ b/src/Conchpiler/op.cpp
@@ -67,7 +67,7 @@ void ConDivOp::Execute()
 void ConSetOp::Execute()
 {
     ConVariableCached *Dst = GetArgAs<ConVariableCached*>(0);
-    const ConVariableCached *Src = GetArgAs<ConVariableCached*>(1);
+    const ConVariable *Src = GetArgAs<ConVariable*>(1);
     Dst->SetVal(Src->GetVal());
 }
 

--- a/src/Conchpiler/parser.cpp
+++ b/src/Conchpiler/parser.cpp
@@ -34,8 +34,15 @@ std::vector<ConBaseOp*> ConParser::ParseTokens(const std::vector<std::string>& T
         const std::string& Tok = Tokens.at(i);
         if (Tok == "SET")
         {
-            ConVariable* Dst = Stack.back(); Stack.pop_back();
+            assert(Stack.size() >= 2);
+
+            ConVariable* RawDst = Stack.back();
+            ConVariableCached* Dst = dynamic_cast<ConVariableCached*>(RawDst);
+            assert(Dst != nullptr && "SET destination must be a cached variable");
+            Stack.pop_back();
+
             ConVariable* Src = Stack.back(); Stack.pop_back();
+
             OpStorage.emplace_back(std::make_unique<ConSetOp>(std::vector<ConVariable*>{Dst, Src}));
             Ops.push_back(OpStorage.back().get());
             Stack.push_back(Dst);


### PR DESCRIPTION
## Summary
- update `ConSetOp::Execute` to treat the source as a generic `ConVariable` so cached and constant inputs work
- ensure `ParseTokens` enforces cached destinations for `SET` while leaving constants on the source side, rejecting illegal forms

## Testing
- g++ -std=c++17 -Isrc/Conchpiler TestApp/TestApp.cpp src/Conchpiler/*.cpp -o testapp
- ./testapp

------
https://chatgpt.com/codex/tasks/task_e_68cef4716990832d9c6791a252c0b3ac