### PR TITLE
Deduplicate per-op variable touches in cycle accounting

### DIFF
--- a/src/Conchpiler/line.cpp
+++ b/src/Conchpiler/line.cpp
@@ -14,10 +14,15 @@ void ConLine::Execute()
 
 void ConLine::UpdateCycleCount()
 {
+    UpdateCycleCount(0);
+}
+
+void ConLine::UpdateCycleCount(const int32 VarCount)
+{
     ConCompilable::UpdateCycleCount();
     for (ConBaseOp* Op : Ops)
     {
-        Op->UpdateCycleCount();
+        Op->UpdateCycleCount(VarCount);
         AddCycles(Op->GetCycleCount());
     }
 }

--- a/src/Conchpiler/line.h
+++ b/src/Conchpiler/line.h
@@ -19,6 +19,7 @@ public:
     virtual  ~ConLine() override;
     virtual void Execute() override;
     virtual void UpdateCycleCount() override;
+    void UpdateCycleCount(int32 VarCount);
     void SetOps(const vector<ConBaseOp*>& Ops);
     void SetCondition(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount, bool bInvert);
     bool IsConditional() const { return Condition != ConConditionOp::None; }

--- a/src/Conchpiler/op.h
+++ b/src/Conchpiler/op.h
@@ -16,7 +16,9 @@ struct ConBaseOp : public ConCompilable
     int32 GetArgsCount() const { return int32(GetArgs().size()); }
 
     virtual void UpdateCycleCount() override;
+    virtual void UpdateCycleCount(int32 VarCount);
     virtual int32 GetBaseCycleCost() const { return 1; }
+    virtual int32 GetVariableAccessCount() const;
 
     template<typename T>
     T GetArgAs(int32 Index);

--- a/src/Conchpiler/thread.cpp
+++ b/src/Conchpiler/thread.cpp
@@ -43,8 +43,7 @@ void ConThread::UpdateCycleCount()
     const int32 VarCount = int32(Variables.size());
     for (ConLine& Line : Lines)
     {
-        Line.UpdateCycleCount();
-        Line.AddCycles(VarCount);
+        Line.UpdateCycleCount(VarCount);
         AddCycles(Line.GetCycleCount());
     }
 }


### PR DESCRIPTION
## Summary
- ensure operation cycle counts only multiply VarCount for distinct thread variables by deduplicating cached operands in ConBaseOp
- document the distinct-variable behavior in the reference manual and highlight optimization strategies that reward reusing registers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cef4aa836c832d9f282cf481c951cd