### PR TITLE
Stabilize cache proxy ownership

### DIFF
--- a/src/Conchpiler/op.cpp
+++ b/src/Conchpiler/op.cpp
@@ -66,15 +66,17 @@ void ConDivOp::Execute()
 
 void ConSetOp::Execute()
 {
-    ConVariableCached *Dst = GetArgAs<ConVariableCached*>(0);
-    const ConVariableCached *Src = GetArgAs<ConVariableCached*>(1);
+    assert(dynamic_cast<ConVariableCached*>(GetArgs().at(0)) != nullptr);
+    ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    const ConVariable* Src = GetArgAs<ConVariable*>(1);
     Dst->SetVal(Src->GetVal());
 }
 
 void ConSwpOp::Execute()
 {
-    ConVariableCached *Dst = GetArgAs<ConVariableCached*>(0);
-    Dst->Swap();   
+    assert(dynamic_cast<ConVariableCached*>(GetArgs().at(0)) != nullptr);
+    ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    Dst->Swap();
 }
 
 

--- a/src/Conchpiler/parser.h
+++ b/src/Conchpiler/parser.h
@@ -16,7 +16,7 @@ private:
     std::vector<std::unique_ptr<ConVariableCached>> VarStorage;
     std::vector<std::unique_ptr<ConVariableAbsolute>> ConstStorage;
     std::vector<std::unique_ptr<ConBaseOp>> OpStorage;
-    std::unordered_map<std::string, ConVariableCached*> VarMap;
+    std::unordered_map<std::string, ConVariable*> VarMap;
 
     ConVariable* ResolveToken(const std::string& Tok);
     std::vector<ConBaseOp*> ParseTokens(const std::vector<std::string>& Tokens);

--- a/src/Conchpiler/variable.cpp
+++ b/src/Conchpiler/variable.cpp
@@ -1,5 +1,44 @@
 #include "variable.h"
 
+ConVariableCached::ConVariableCached()
+    : CacheAccessor(*this)
+{
+}
+
+ConVariableCached::ConVariableCached(const ConVariableCached& Other)
+    : CacheAccessor(*this)
+    , Val(Other.Val)
+    , Cache(Other.Cache)
+{
+}
+
+ConVariableCached& ConVariableCached::operator=(const ConVariableCached& Other)
+{
+    if (this != &Other)
+    {
+        Val = Other.Val;
+        Cache = Other.Cache;
+    }
+    return *this;
+}
+
+ConVariableCached::ConVariableCached(ConVariableCached&& Other) noexcept
+    : CacheAccessor(*this)
+    , Val(Other.Val)
+    , Cache(Other.Cache)
+{
+}
+
+ConVariableCached& ConVariableCached::operator=(ConVariableCached&& Other) noexcept
+{
+    if (this != &Other)
+    {
+        Val = Other.Val;
+        Cache = Other.Cache;
+    }
+    return *this;
+}
+
 int32 ConVariableAbsolute::GetVal() const
 {
     return Val;
@@ -26,6 +65,11 @@ int32 ConVariableCached::GetCache() const
     return Cache;
 }
 
+void ConVariableCached::SetCache(const int32 NewVal)
+{
+    Cache = NewVal;
+}
+
 void ConVariableCached::Swap()
 {
     const int32 Temp = Val;
@@ -39,4 +83,14 @@ ConVariableCached ConVariableCached::SwapInPlace()
     Val = Cache;
     Cache = Temp;
     return *this;
+}
+
+ConVariable* ConVariableCached::GetCacheVariable()
+{
+    return &CacheAccessor;
+}
+
+const ConVariable* ConVariableCached::GetCacheVariable() const
+{
+    return &CacheAccessor;
 }

--- a/src/Conchpiler/variable.h
+++ b/src/Conchpiler/variable.h
@@ -22,15 +22,37 @@ private:
 
 struct ConVariableCached : public ConVariable
 {
+    ConVariableCached();
+    ConVariableCached(const ConVariableCached& Other);
+    ConVariableCached& operator=(const ConVariableCached& Other);
+    ConVariableCached(ConVariableCached&& Other) noexcept;
+    ConVariableCached& operator=(ConVariableCached&& Other) noexcept;
+
     virtual int32 GetVal() const override;
     virtual void SetVal(int32 NewVal) override;
     int32 GetCache() const;
+    void SetCache(int32 NewVal);
     // swaps the value and the cache
     void Swap();
     ConVariableCached SwapInPlace();
-    
+
+    ConVariable* GetCacheVariable();
+    const ConVariable* GetCacheVariable() const;
+
 private:
-    
+    struct CacheProxy : public ConVariable
+    {
+        explicit CacheProxy(ConVariableCached& InOwner)
+            : Owner(InOwner) {}
+
+        virtual int32 GetVal() const override { return Owner.GetCache(); }
+        virtual void SetVal(int32 NewVal) override { Owner.SetCache(NewVal); }
+
+    private:
+        ConVariableCached& Owner;
+    };
+
+    CacheProxy CacheAccessor;
     int32 Val = 0;
     int32 Cache = 0;
 };


### PR DESCRIPTION
## Summary
- add copy and move support to `ConVariableCached` so its cache proxy always tracks the owning register
- rely on typed access in SET/SWP execution while keeping debug-time assertions for cache-only operations

## Testing
- not run (no build tooling available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cef4b75094832d80d16b96e8ef84c8