### PR TITLE
Refactor binary operations and simplify parser helpers

### DIFF
--- a/src/Conchpiler/op.cpp
+++ b/src/Conchpiler/op.cpp
@@ -59,47 +59,48 @@ vector<const ConVariable*> ConContextualReturnOp::GetSrcArg() const
     return {GetDstArg(), GetArgs().at(1)};
 }
 
-void ConAddOp::Execute()
+ConBinaryOp::ConBinaryOp(const ConBinaryOpKind InKind, const vector<ConVariable*>& InArgs)
+    : ConContextualReturnOp(InArgs)
+    , Kind(InKind)
 {
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() + SrcArg.at(1)->GetVal());   
 }
 
-void ConMulOp::Execute()
+void ConBinaryOp::Execute()
 {
     const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() * SrcArg.at(1)->GetVal()); 
-}
+    const int32 Lhs = SrcArg.at(0)->GetVal();
+    const int32 Rhs = SrcArg.at(1)->GetVal();
 
-void ConSubOp::Execute()
-{
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() - SrcArg.at(1)->GetVal());
-}
+    int32 Result = 0;
+    switch (Kind)
+    {
+    case ConBinaryOpKind::Add:
+        Result = Lhs + Rhs;
+        break;
+    case ConBinaryOpKind::Sub:
+        Result = Lhs - Rhs;
+        break;
+    case ConBinaryOpKind::Mul:
+        Result = Lhs * Rhs;
+        break;
+    case ConBinaryOpKind::Div:
+        Result = (Rhs == 0) ? 0 : Lhs / Rhs;
+        break;
+    case ConBinaryOpKind::And:
+        Result = Lhs & Rhs;
+        break;
+    case ConBinaryOpKind::Or:
+        Result = Lhs | Rhs;
+        break;
+    case ConBinaryOpKind::Xor:
+        Result = Lhs ^ Rhs;
+        break;
+    default:
+        assert(false);
+        break;
+    }
 
-void ConDivOp::Execute()
-{
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    const int32 B = SrcArg.at(1)->GetVal();
-    GetDstArg()->SetVal(B == 0 ? 0 : SrcArg.at(0)->GetVal() / B);
-}
-
-void ConAndOp::Execute()
-{
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() & SrcArg.at(1)->GetVal());
-}
-
-void ConOrOp::Execute()
-{
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() | SrcArg.at(1)->GetVal());
-}
-
-void ConXorOp::Execute()
-{
-    const vector<const ConVariable*> SrcArg = GetSrcArg();
-    GetDstArg()->SetVal(SrcArg.at(0)->GetVal() ^ SrcArg.at(1)->GetVal());
+    GetDstArg()->SetVal(Result);
 }
 
 void ConIncrOp::Execute()

--- a/src/Conchpiler/op.h
+++ b/src/Conchpiler/op.h
@@ -44,46 +44,24 @@ struct ConContextualReturnOp : public ConBaseOp
     vector<const ConVariable*> GetSrcArg() const;
 };
 
-struct ConAddOp final : public ConContextualReturnOp
+enum class ConBinaryOpKind
 {
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
+    Add,
+    Sub,
+    Mul,
+    Div,
+    And,
+    Or,
+    Xor
 };
 
-struct ConMulOp final : public ConContextualReturnOp
+struct ConBinaryOp final : public ConContextualReturnOp
 {
-    using ConContextualReturnOp::ConContextualReturnOp;
+    ConBinaryOp(ConBinaryOpKind InKind, const std::vector<ConVariable*>& InArgs);
     virtual void Execute() override;
-};
 
-struct ConSubOp final : public ConContextualReturnOp
-{
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
-};
-
-struct ConDivOp final : public ConContextualReturnOp
-{
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
-};
-
-struct ConAndOp final : public ConContextualReturnOp
-{
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
-};
-
-struct ConOrOp final : public ConContextualReturnOp
-{
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
-};
-
-struct ConXorOp final : public ConContextualReturnOp
-{
-    using ConContextualReturnOp::ConContextualReturnOp;
-    virtual void Execute() override;
+private:
+    ConBinaryOpKind Kind;
 };
 
 struct ConIncrOp final : public ConBaseOp


### PR DESCRIPTION
## Summary
- replace the duplicated ADD/SUB/MUL/etc. opcode structs with a single configurable ConBinaryOp
- rework ParseTokens helper utilities to reuse a centralized binary op map and shared stack helpers
- streamline inline SET handling so opcode creation is easier to follow as new instructions are added

## Testing
- Not Run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0d57c85fc832da40ececf1ec07069