### PR TITLE
Add parser reset and isolate per-parse storage

### DIFF
--- a/src/Conchpiler/parser.cpp
+++ b/src/Conchpiler/parser.cpp
@@ -27,6 +27,17 @@ bool IsComparisonToken(const std::string& Comp)
 
 ConParser::ConParser()
 {
+    Reset();
+}
+
+void ConParser::Reset()
+{
+    VarStorage.clear();
+    ConstStorage.clear();
+    ListStorage.clear();
+    OpStorage.clear();
+    VarMap.clear();
+
     const std::array<std::string, 3> BaseVars = {"X", "Y", "Z"};
     for (const std::string& Name : BaseVars)
     {
@@ -398,6 +409,7 @@ struct ParsedLine
 
 bool ConParser::Parse(const std::vector<std::string>& Lines, ConThread& OutThread)
 {
+    Reset();
     Errors.clear();
     bHadError = false;
 
@@ -639,7 +651,8 @@ bool ConParser::Parse(const std::vector<std::string>& Lines, ConThread& OutThrea
         }
         Thread.ConstructLine(Line);
     }
-    OutThread = Thread;
+    Thread.SetOwnedStorage(std::move(VarStorage), std::move(ConstStorage), std::move(ListStorage), std::move(OpStorage));
+    OutThread = std::move(Thread);
     return true;
 }
 

--- a/src/Conchpiler/parser.h
+++ b/src/Conchpiler/parser.h
@@ -15,6 +15,8 @@ struct ConParser
     const std::vector<std::string>& GetErrors() const { return Errors; }
 
 private:
+    void Reset();
+
     std::vector<std::unique_ptr<ConVariableCached>> VarStorage;
     std::vector<std::unique_ptr<ConVariableAbsolute>> ConstStorage;
     std::vector<std::unique_ptr<ConVariableList>> ListStorage;

--- a/src/Conchpiler/thread.cpp
+++ b/src/Conchpiler/thread.cpp
@@ -2,6 +2,7 @@
 #include "thread.h"
 #include <iostream>
 #include <ostream>
+#include <utility>
 
 void ConThread::Execute()
 {
@@ -131,6 +132,17 @@ void ConThread::UpdateCycleCount()
 void ConThread::SetVariables(const vector<ConVariable*>& InVariables)
 {
     Variables = InVariables;
+}
+
+void ConThread::SetOwnedStorage(std::vector<std::unique_ptr<ConVariableCached>>&& CachedVars,
+                                std::vector<std::unique_ptr<ConVariableAbsolute>>&& ConstVars,
+                                std::vector<std::unique_ptr<ConVariableList>>&& ListVars,
+                                std::vector<std::unique_ptr<ConBaseOp>>&& Ops)
+{
+    OwnedVarStorage = std::move(CachedVars);
+    OwnedConstStorage = std::move(ConstVars);
+    OwnedListStorage = std::move(ListVars);
+    OwnedOpStorage = std::move(Ops);
 }
 
 void ConThread::ConstructLine(const ConLine &Line)

--- a/src/Conchpiler/thread.h
+++ b/src/Conchpiler/thread.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "line.h"
 #include "variable.h"
+#include <memory>
 
 struct ConThread final : public ConCompilable
 {
@@ -10,9 +11,17 @@ public:
     virtual void Execute() override;
     virtual void UpdateCycleCount() override;
     void SetVariables(const vector<ConVariable*>& InVariables);
+    void SetOwnedStorage(std::vector<std::unique_ptr<ConVariableCached>>&& CachedVars,
+                         std::vector<std::unique_ptr<ConVariableAbsolute>>&& ConstVars,
+                         std::vector<std::unique_ptr<ConVariableList>>&& ListVars,
+                         std::vector<std::unique_ptr<ConBaseOp>>&& Ops);
     void ConstructLine(const ConLine& Line);
-    
+
 private:
     vector<ConVariable*> Variables;
     vector<ConLine> Lines;
+    std::vector<std::unique_ptr<ConVariableCached>> OwnedVarStorage;
+    std::vector<std::unique_ptr<ConVariableAbsolute>> OwnedConstStorage;
+    std::vector<std::unique_ptr<ConVariableList>> OwnedListStorage;
+    std::vector<std::unique_ptr<ConBaseOp>> OwnedOpStorage;
 };


### PR DESCRIPTION
## Summary
- add a reusable Reset helper that clears parser storage and rebuilds base thread variables
- reset parser state at the start of Parse so each compilation run begins with fresh variables and caches
- transfer variable, constant, list, and op storage ownership to ConThread to keep per-program data isolated

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0df7c1da0832d8fb0e7be12d2b43e