### PR TITLE
Improve error diagnostics and runtime safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,10 @@ Comments:
 
 Not allowed in real code.
 (Training examples may include them, but they are invalid in-game.)
+
+## Troubleshooting & Diagnostics
+
+* Parse-time mistakes now surface as `[line N, col M]` messages from `ConParser::Parse`. `Parser.GetErrors()` preserves the full list so you can diff tweaks quickly when chasing a faster solution.
+* Runtime mistakes (for example, trying to `POP` into a literal or feeding a `NOT` without a source) bubble up through `ConThread`. The thread stops immediately, `HadRuntimeError()` flips to true, and `GetRuntimeErrors()` returns the formatted messages. They are also echoed to stderr so you do not miss them while watching register dumps.
+* Cycle-count instrumentation is frozen as soon as a runtime error fires. That means you can experiment with aggressive inline tricks or risky LIST juggling without corrupting your performance baseline—fix the reported issue and re-run to compare cycles apples-to-apples.
+* When optimising for cycles, lean into the new diagnostics: use them to validate that an inline rewrite still targets thread variables (mis-tagged literals are a common culprit), and iterate on cache-heavy strategies that keep the distinct-variable multiplier low.

--- a/TestApp/TestApp.cpp
+++ b/TestApp/TestApp.cpp
@@ -34,6 +34,15 @@ int main(int Argc, char* Argv[])
 
     Thread.UpdateCycleCount();
     Thread.Execute();
+    if (Thread.HadRuntimeError())
+    {
+        std::cout << "Runtime error(s) encountered:\n";
+        for (const std::string& Error : Thread.GetRuntimeErrors())
+        {
+            std::cout << "  " << Error << std::endl;
+        }
+        return 1;
+    }
     std::cout << "Total cycles: " << Thread.GetCycleCount() << std::endl;
     return 0;
 }

--- a/src/Conchpiler/common.h
+++ b/src/Conchpiler/common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <vector>
 
 using namespace std;

--- a/src/Conchpiler/errors.h
+++ b/src/Conchpiler/errors.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "common.h"
+#include "scanner.h"
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+inline std::string FormatErrorMessage(const ConSourceLocation& Location, const std::string& Message)
+{
+    std::ostringstream Stream;
+    if (Location.IsValid())
+    {
+        Stream << "[line " << Location.Line << ", col " << Location.Column << "] ";
+    }
+    Stream << Message;
+    return Stream.str();
+}
+
+struct ConParseError : public std::runtime_error
+{
+    ConParseError(const Token& InToken, const std::string& InMessage)
+        : std::runtime_error(InMessage)
+        , TokenInfo(InToken)
+    {
+        Location.Line = InToken.Line;
+        Location.Column = InToken.Column;
+    }
+
+    Token TokenInfo;
+    ConSourceLocation Location;
+};
+
+struct ConRuntimeError : public std::runtime_error
+{
+    ConRuntimeError(const ConSourceLocation& InLocation, const std::string& InMessage)
+        : std::runtime_error(InMessage)
+        , Location(InLocation)
+    {
+    }
+
+    ConSourceLocation Location;
+};
+

--- a/src/Conchpiler/line.cpp
+++ b/src/Conchpiler/line.cpp
@@ -1,5 +1,7 @@
 #include "line.h"
 
+#include "errors.h"
+
 ConLine::~ConLine()
 {
 }
@@ -165,6 +167,16 @@ void ConLine::SetJump(int32 TargetIndex, ConConditionOp Op, ConVariable* Lhs, Co
 
 bool ConLine::EvaluateCondition() const
 {
+    if (Condition == ConConditionOp::None)
+    {
+        return Invert ? false : true;
+    }
+
+    if (Left == nullptr || Right == nullptr)
+    {
+        throw ConRuntimeError(Location, "Condition requires two operands");
+    }
+
     bool Result = true;
     switch (Condition)
     {
@@ -178,7 +190,6 @@ bool ConLine::EvaluateCondition() const
         Result = Left->GetVal() == Right->GetVal();
         break;
     default:
-        Result = true;
         break;
     }
     return Invert ? !Result : Result;

--- a/src/Conchpiler/op.cpp
+++ b/src/Conchpiler/op.cpp
@@ -1,16 +1,23 @@
 #include "op.h"
+
 #include <unordered_set>
 
 void ConBaseOp::SetArgs(const vector<ConVariable*> Args)
 {
-    assert(GetArgsCount() <= GetMaxArgs());
+    if (Args.size() > static_cast<size_t>(GetMaxArgs()))
+    {
+        throw ConRuntimeError(GetSourceLocation(), "Too many arguments supplied to operation");
+    }
     this->Args = Args;
 }
 
 ConVariable* ConBaseOp::GetReturn() const
 {
-    assert(HasReturn());
-    return nullptr;
+    if (!HasReturn() || GetArgs().empty())
+    {
+        return nullptr;
+    }
+    return GetArgs().front();
 }
 
 const vector<ConVariable*> &ConBaseOp::GetArgs() const
@@ -46,12 +53,19 @@ int32 ConBaseOp::GetVariableAccessCount() const
 
 ConVariable* ConContextualReturnOp::GetDstArg() const
 {
-    assert(GetArgsCount() > 0);
+    if (GetArgsCount() == 0)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "Operation missing destination argument");
+    }
     return GetArgs().at(0);
 }
 
 vector<const ConVariable*> ConContextualReturnOp::GetSrcArg() const
 {
+    if (GetArgsCount() < 2)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "Operation missing source argument");
+    }
     if (GetArgsCount() == 3)
     {
         return {GetArgs().at(1), GetArgs().at(2)};
@@ -68,6 +82,17 @@ ConBinaryOp::ConBinaryOp(const ConBinaryOpKind InKind, const vector<ConVariable*
 void ConBinaryOp::Execute()
 {
     const vector<const ConVariable*> SrcArg = GetSrcArg();
+    if (SrcArg.size() < 2 || SrcArg.at(0) == nullptr || SrcArg.at(1) == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "Binary operation missing operands");
+    }
+
+    ConVariableCached* Dst = dynamic_cast<ConVariableCached*>(GetDstArg());
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "Binary operation destination must be a thread variable");
+    }
+
     const int32 Lhs = SrcArg.at(0)->GetVal();
     const int32 Rhs = SrcArg.at(1)->GetVal();
 
@@ -96,28 +121,51 @@ void ConBinaryOp::Execute()
         Result = Lhs ^ Rhs;
         break;
     default:
-        assert(false);
-        break;
+        throw ConRuntimeError(GetSourceLocation(), "Unknown binary operation");
     }
 
-    GetDstArg()->SetVal(Result);
+    Dst->SetVal(Result);
 }
 
 void ConIncrOp::Execute()
 {
+    if (GetArgsCount() < 1)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "INCR requires a destination argument");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "INCR destination must be a thread variable");
+    }
     Dst->SetVal(Dst->GetVal() + 1);
 }
 
 void ConDecrOp::Execute()
 {
+    if (GetArgsCount() < 1)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "DECR requires a destination argument");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "DECR destination must be a thread variable");
+    }
     Dst->SetVal(Dst->GetVal() - 1);
 }
 
 void ConNotOp::Execute()
 {
+    if (GetArgsCount() < 1)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "NOT requires a destination argument");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "NOT destination must be a thread variable");
+    }
     if (GetArgsCount() == 1)
     {
         Dst->SetVal(~Dst->GetVal());
@@ -125,41 +173,87 @@ void ConNotOp::Execute()
     else
     {
         const ConVariable* Src = GetArgAs<ConVariable*>(1);
+        if (Src == nullptr)
+        {
+            throw ConRuntimeError(GetSourceLocation(), "NOT source argument is invalid");
+        }
         Dst->SetVal(~Src->GetVal());
     }
 }
 
 void ConPopOp::Execute()
 {
-    assert(GetArgsCount() >= 2);
+    if (GetArgsCount() < 2)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "POP requires a destination and a list argument");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "POP destination must be a thread variable");
+    }
     ConVariableList* List = dynamic_cast<ConVariableList*>(GetArgAs<ConVariable*>(1));
-    assert(List != nullptr);
+    if (List == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "POP requires a list operand");
+    }
     Dst->SetVal(List->Pop());
 }
 
 void ConAtOp::Execute()
 {
-    assert(GetArgsCount() >= 3);
+    if (GetArgsCount() < 3)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "AT requires a destination, list, and index");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "AT destination must be a thread variable");
+    }
     ConVariableList* List = dynamic_cast<ConVariableList*>(GetArgAs<ConVariable*>(1));
-    assert(List != nullptr);
+    if (List == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "AT requires a list operand");
+    }
     const ConVariable* IndexVar = GetArgAs<ConVariable*>(2);
+    if (IndexVar == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "AT index argument is invalid");
+    }
     Dst->SetVal(List->At(IndexVar->GetVal()));
 }
 
 void ConSetOp::Execute()
 {
-    assert(dynamic_cast<ConVariableCached*>(GetArgs().at(0)) != nullptr);
+    if (GetArgsCount() < 2)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "SET requires a destination and a source");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "SET destination must be a thread variable");
+    }
     const ConVariable* Src = GetArgAs<ConVariable*>(1);
+    if (Src == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "SET source argument is invalid");
+    }
     Dst->SetVal(Src->GetVal());
 }
 
 void ConSwpOp::Execute()
 {
-    assert(dynamic_cast<ConVariableCached*>(GetArgs().at(0)) != nullptr);
+    if (GetArgsCount() < 1)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "SWP requires a destination argument");
+    }
     ConVariableCached* Dst = GetArgAs<ConVariableCached*>(0);
+    if (Dst == nullptr)
+    {
+        throw ConRuntimeError(GetSourceLocation(), "SWP destination must be a thread variable");
+    }
     Dst->Swap();
 }
 

--- a/src/Conchpiler/op.h
+++ b/src/Conchpiler/op.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "common.h"
 #include "compilable.h"
+#include "errors.h"
 #include "variable.h"
 
 struct ConBaseOp : public ConCompilable
@@ -34,7 +35,11 @@ private:
 template <typename T>
 T ConBaseOp::GetArgAs(const int32 Index)
 {
-    return static_cast<T>(GetArgs().at(Index));
+    if (Index < 0 || static_cast<size_t>(Index) >= GetArgs().size())
+    {
+        return nullptr;
+    }
+    return dynamic_cast<T>(GetArgs().at(Index));
 }
 
 // if has return operate on last 2 args and place result in arg[0] if in-place, operate on 2 args and replace value of first 

--- a/src/Conchpiler/parser.h
+++ b/src/Conchpiler/parser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "errors.h"
 #include "scanner.h"
 #include "thread.h"
 #include <memory>
@@ -13,6 +14,7 @@ struct ConParser
 
     bool Parse(const vector<string>& Lines, ConThread& OutThread);
     const std::vector<std::string>& GetErrors() const { return Errors; }
+    bool HadError() const { return bHadError; }
 
 private:
     void Reset();
@@ -28,5 +30,6 @@ private:
     ConVariable* ResolveToken(const Token& Tok);
     std::vector<ConBaseOp*> ParseTokens(const std::vector<Token>& Tokens);
     void ReportError(const Token& Tok, const std::string& Message);
+    void ReportError(const ConParseError& Error);
 };
 

--- a/src/Conchpiler/thread.h
+++ b/src/Conchpiler/thread.h
@@ -2,6 +2,8 @@
 #include "line.h"
 #include "variable.h"
 #include <memory>
+#include <string>
+#include <vector>
 
 struct ConThread final : public ConCompilable
 {
@@ -17,11 +19,19 @@ public:
                          std::vector<std::unique_ptr<ConBaseOp>>&& Ops);
     void ConstructLine(const ConLine& Line);
 
+    bool HadRuntimeError() const { return bHadRuntimeError; }
+    const std::vector<std::string>& GetRuntimeErrors() const { return RuntimeErrors; }
+
 private:
+    void ReportRuntimeError(const ConRuntimeError& Error);
+    void ResetRuntimeErrors();
+
     vector<ConVariable*> Variables;
     vector<ConLine> Lines;
     std::vector<std::unique_ptr<ConVariableCached>> OwnedVarStorage;
     std::vector<std::unique_ptr<ConVariableAbsolute>> OwnedConstStorage;
     std::vector<std::unique_ptr<ConVariableList>> OwnedListStorage;
     std::vector<std::unique_ptr<ConBaseOp>> OwnedOpStorage;
+    std::vector<std::string> RuntimeErrors;
+    bool bHadRuntimeError = false;
 };


### PR DESCRIPTION
## Summary
- add dedicated parse/runtime error types and use them throughout parsing and opcode execution instead of assertions
- introduce ConThread runtime error reporting so execution halts cleanly and exposes formatted diagnostics
- document the new troubleshooting workflow in the README and surface runtime errors in the sample TestApp

## Testing
- g++ -std=c++17 src/Conchpiler/*.cpp TestApp/TestApp.cpp -o testapp
- ./testapp

------
https://chatgpt.com/codex/tasks/task_e_68d0e18f907c832db68f78b2bb22f6d4