### PR TITLE
Introduce typed variable references and thread mix analytics

### DIFF
--- a/src/Conchpiler/line.h
+++ b/src/Conchpiler/line.h
@@ -30,10 +30,10 @@ public:
     virtual void UpdateCycleCount() override;
     void UpdateCycleCount(int32 VarCount);
     void SetOps(const vector<ConBaseOp*>& InOps, ConSourceLocation InLocation);
-    void SetIf(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, int32 SkipCount, bool bInvert, ConSourceLocation InLocation);
-    void SetLoop(ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, bool bInvert, int32 ExitIndex, ConSourceLocation InLocation);
-    void SetRedo(int32 TargetIndex, ConVariableCached* CounterVar, bool bInfinite, ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, bool bInvert, ConSourceLocation InLocation);
-    void SetJump(int32 TargetIndex, ConConditionOp Op, ConVariable* Lhs, ConVariable* Rhs, bool bInvert, ConSourceLocation InLocation);
+    void SetIf(ConConditionOp Op, VariableRef Lhs, VariableRef Rhs, int32 SkipCount, bool bInvert, ConSourceLocation InLocation);
+    void SetLoop(ConConditionOp Op, VariableRef Lhs, VariableRef Rhs, bool bInvert, int32 ExitIndex, ConSourceLocation InLocation);
+    void SetRedo(int32 TargetIndex, VariableRef CounterVar, bool bInfinite, ConConditionOp Op, VariableRef Lhs, VariableRef Rhs, bool bInvert, ConSourceLocation InLocation);
+    void SetJump(int32 TargetIndex, ConConditionOp Op, VariableRef Lhs, VariableRef Rhs, bool bInvert, ConSourceLocation InLocation);
 
     ConLineKind GetKind() const { return Kind; }
     bool HasCondition() const { return Condition != ConConditionOp::None; }
@@ -41,8 +41,8 @@ public:
     int32 GetSkipCount() const { return Skip; }
     int32 GetLoopExitIndex() const { return LoopExitIndex; }
     int32 GetTargetIndex() const { return TargetIndex; }
-    ConVariableCached* GetCounterVar() const { return Counter; }
-    bool HasCounter() const { return Counter != nullptr; }
+    const VariableRef& GetCounter() const { return Counter; }
+    bool HasCounter() const { return Counter.IsThread(); }
     bool IsInfiniteLoop() const { return bInfiniteLoop; }
     const ConSourceLocation& GetLocation() const { return Location; }
 
@@ -51,12 +51,12 @@ private:
     vector<ConBaseOp*> Ops;
     ConLineKind Kind = ConLineKind::Ops;
     ConConditionOp Condition = ConConditionOp::None;
-    ConVariable* Left = nullptr;
-    ConVariable* Right = nullptr;
+    VariableRef Left;
+    VariableRef Right;
     int32 Skip = 0;
     int32 LoopExitIndex = -1;
     int32 TargetIndex = -1;
-    ConVariableCached* Counter = nullptr;
+    VariableRef Counter;
     bool bInfiniteLoop = false;
     bool Invert = false;
     ConSourceLocation Location;

--- a/src/Conchpiler/parser.h
+++ b/src/Conchpiler/parser.h
@@ -23,11 +23,11 @@ private:
     std::vector<std::unique_ptr<ConVariableAbsolute>> ConstStorage;
     std::vector<std::unique_ptr<ConVariableList>> ListStorage;
     std::vector<std::unique_ptr<ConBaseOp>> OpStorage;
-    std::unordered_map<std::string, ConVariable*> VarMap;
+    std::unordered_map<std::string, VariableRef> VarMap;
     std::vector<std::string> Errors;
     bool bHadError = false;
 
-    ConVariable* ResolveToken(const Token& Tok);
+    VariableRef ResolveToken(const Token& Tok);
     std::vector<ConBaseOp*> ParseTokens(const std::vector<Token>& Tokens);
     void ReportError(const Token& Tok, const std::string& Message);
     void ReportError(const ConParseError& Error);

--- a/src/Conchpiler/thread.h
+++ b/src/Conchpiler/thread.h
@@ -8,11 +8,11 @@
 struct ConThread final : public ConCompilable
 {
 public:
-    ConThread(): Variables() {}
-    explicit ConThread(const vector<ConVariable*> &InVariables) : Variables(InVariables) {}
+    ConThread() : ThreadVariables() {}
+    explicit ConThread(const vector<ConVariableCached*>& InVariables) : ThreadVariables(InVariables) {}
     virtual void Execute() override;
     virtual void UpdateCycleCount() override;
-    void SetVariables(const vector<ConVariable*>& InVariables);
+    void SetVariables(const vector<ConVariableCached*>& InVariables);
     void SetOwnedStorage(std::vector<std::unique_ptr<ConVariableCached>>&& CachedVars,
                          std::vector<std::unique_ptr<ConVariableAbsolute>>&& ConstVars,
                          std::vector<std::unique_ptr<ConVariableList>>&& ListVars,
@@ -26,7 +26,7 @@ private:
     void ReportRuntimeError(const ConRuntimeError& Error);
     void ResetRuntimeErrors();
 
-    vector<ConVariable*> Variables;
+    vector<ConVariableCached*> ThreadVariables;
     vector<ConLine> Lines;
     std::vector<std::unique_ptr<ConVariableCached>> OwnedVarStorage;
     std::vector<std::unique_ptr<ConVariableAbsolute>> OwnedConstStorage;

--- a/src/Conchpiler/variable.cpp
+++ b/src/Conchpiler/variable.cpp
@@ -169,3 +169,54 @@ void ConVariableList::Reset()
         CurrentValue = 0;
     }
 }
+
+VariableRef::VariableRef(const VariableKind InKind, ConVariable* const InPtr, ConVariableCached* const InOwner)
+    : Kind(InKind)
+    , Ptr(InPtr)
+    , ThreadOwner((InKind == VariableKind::Thread || InKind == VariableKind::Cache) ? InOwner : nullptr)
+{
+}
+
+VariableRef VariableRef::ThreadVar(ConVariableCached* const Var)
+{
+    return VariableRef(VariableKind::Thread, Var, Var);
+}
+
+VariableRef VariableRef::CacheVar(ConVariableCached* const Var)
+{
+    ConVariable* CachePtr = Var != nullptr ? Var->GetCacheVariable() : nullptr;
+    return VariableRef(VariableKind::Cache, CachePtr, Var);
+}
+
+VariableRef VariableRef::ListVar(ConVariableList* const Var)
+{
+    return VariableRef(VariableKind::List, Var, nullptr);
+}
+
+VariableRef VariableRef::LiteralVar(ConVariableAbsolute* const Var)
+{
+    return VariableRef(VariableKind::Literal, Var, nullptr);
+}
+
+ConVariableList* VariableRef::GetList() const
+{
+    return (Kind == VariableKind::List) ? static_cast<ConVariableList*>(Ptr) : nullptr;
+}
+
+ConVariableAbsolute* VariableRef::GetLiteral() const
+{
+    return (Kind == VariableKind::Literal) ? static_cast<ConVariableAbsolute*>(Ptr) : nullptr;
+}
+
+int32 VariableRef::Read() const
+{
+    return Ptr != nullptr ? Ptr->GetVal() : 0;
+}
+
+void VariableRef::Write(const int32 Value) const
+{
+    if (Ptr != nullptr)
+    {
+        Ptr->SetVal(Value);
+    }
+}

--- a/src/Conchpiler/variable.h
+++ b/src/Conchpiler/variable.h
@@ -1,6 +1,14 @@
 #pragma once
 #include "common.h"
 
+enum class VariableKind
+{
+    Thread,
+    Cache,
+    List,
+    Literal
+};
+
 struct ConVariable
 {
     ConVariable() = default;
@@ -76,4 +84,37 @@ private:
     vector<int32> Storage;
     mutable int32 CurrentValue = 0;
     size_t Cursor = 0;
+};
+
+struct VariableRef
+{
+    VariableRef() = default;
+    VariableRef(VariableKind InKind, ConVariable* InPtr, ConVariableCached* InOwner = nullptr);
+
+    static VariableRef ThreadVar(ConVariableCached* Var);
+    static VariableRef CacheVar(ConVariableCached* Var);
+    static VariableRef ListVar(ConVariableList* Var);
+    static VariableRef LiteralVar(ConVariableAbsolute* Var);
+
+    bool IsValid() const { return Ptr != nullptr; }
+    VariableKind GetKind() const { return Kind; }
+    bool IsThread() const { return Kind == VariableKind::Thread; }
+    bool IsCache() const { return Kind == VariableKind::Cache; }
+    bool IsList() const { return Kind == VariableKind::List; }
+    bool IsLiteral() const { return Kind == VariableKind::Literal; }
+    bool TouchesThread() const { return Kind == VariableKind::Thread || Kind == VariableKind::Cache; }
+
+    ConVariable* GetVariable() const { return Ptr; }
+    ConVariableCached* GetThread() const { return IsThread() ? ThreadOwner : nullptr; }
+    ConVariableCached* GetThreadOwner() const { return ThreadOwner; }
+    ConVariableList* GetList() const;
+    ConVariableAbsolute* GetLiteral() const;
+
+    int32 Read() const;
+    void Write(int32 Value) const;
+
+private:
+    VariableKind Kind = VariableKind::Literal;
+    ConVariable* Ptr = nullptr;
+    ConVariableCached* ThreadOwner = nullptr;
 };


### PR DESCRIPTION
## Summary
- add VariableKind and VariableRef so variable pointers carry their kind for branchless lookups
- refactor parser, thread execution, and line handling to consume typed VariableRef values while exposing thread-mix analytics via ThreadMixSummary
- update all ops to use typed operands, enabling literal folding and removing dynamic_cast checks

## Testing
- not run (build tooling not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0e575d308832d87071480e871892e