### PR TITLE
Add JSON-driven puzzle IDE prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,54 @@ Not allowed in real code.
 * Runtime mistakes (for example, trying to `POP` into a literal or feeding a `NOT` without a source) bubble up through `ConThread`. The thread stops immediately, `HadRuntimeError()` flips to true, and `GetRuntimeErrors()` returns the formatted messages. They are also echoed to stderr so you do not miss them while watching register dumps.
 * Cycle-count instrumentation is frozen as soon as a runtime error fires. That means you can experiment with aggressive inline tricks or risky LIST juggling without corrupting your performance baseline—fix the reported issue and re-run to compare cycles apples-to-apples.
 * When optimising for cycles, lean into the new diagnostics: use them to validate that an inline rewrite still targets thread variables (mis-tagged literals are a common culprit), and iterate on cache-heavy strategies that keep the distinct-variable multiplier low.
+
+## Prototype Puzzle IDE
+
+`TestApp` now doubles as a lightweight IDE for loading puzzle metadata, editing Conch programs, and running regression tests against curated inputs. It is intentionally barebones but geared toward tinkering: you can enter code directly in the console or pull it from disk, run the provided test battery, and immediately see whether you have squeezed the cycle count past your previous best.
+
+### Running the IDE
+
+```
+conch_ide <path/to/puzzle.json> [optional_code_file]
+```
+
+* The puzzle file drives the entire session. It defines the narrative description, a starter (or "naive") solution, and a set of test data to validate against.
+* Pass an optional second argument to preload a solution file. Otherwise the starter program from the puzzle is loaded.
+* Inside the tool you can view puzzle notes, edit code, reload from disk, or run the full test suite. Cycle estimates are reported up front so you can see how far you are from the recorded personal best.
+
+### Puzzle JSON Layout
+
+```json
+{
+  "title": "Example Puzzle",
+  "description": "Tell the story of the challenge and what the output should look like.",
+  "starter": ["SET X 0", "RET"],
+  "tests": [
+    {
+      "name": "Basic smoke test",
+      "registers": {"X": 3, "Y": 0},
+      "lists": [
+        {"index": 0, "values": [1, 2, 3]}
+      ],
+      "expectedRegisters": {"X": 9},
+      "expectedLists": [
+        {"index": 0, "values": [1, 2, 3, 9]}
+      ]
+    }
+  ],
+  "history": [
+    {"label": "Naive", "cycles": 240},
+    {"label": "Personal Best", "cycles": 121}
+  ]
+}
+```
+
+Key details:
+
+* **`starter` / `starterCode` / `naiveSolution`**: any of these keys can supply the initial program. The IDE falls back to a minimal `RET` if none are provided, so you are never forced to start from scratch.
+* **`tests`**: every test case may seed registers (`X`, `Y`, `Z`) and any number of `LIST` variables before execution begins. Expectations are optional but will flag mismatches so you can confirm behaviour after aggressive optimisations.
+* **`history`**: optional running log of noteworthy cycle counts. The IDE surfaces the best historical record so you always know the score you are trying to beat.
+
+### Optimisation Feedback
+
+When you run the suite the IDE prints a static cycle estimate and compares it with the best entry in the puzzle history. That keeps the optimisation loop tight: tweak your inline ops, lean on caches to minimise variable touches, and instantly confirm whether the latest rewrite saved cycles. Expectation failures and runtime errors are reported with their locations so debugging remains straightforward even as your solutions become more intricate.

--- a/TestApp/Puzzle.cpp
+++ b/TestApp/Puzzle.cpp
@@ -1,0 +1,289 @@
+#include "Puzzle.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <initializer_list>
+#include <sstream>
+
+namespace
+{
+std::string ToUpper(const std::string& Text)
+{
+    std::string Result = Text;
+    std::transform(Result.begin(), Result.end(), Result.begin(), [](unsigned char Ch) { return static_cast<char>(std::toupper(Ch)); });
+    return Result;
+}
+
+bool ExtractStringArray(const SimpleJsonValue& Value, std::vector<std::string>& OutStrings, std::string& OutError)
+{
+    if (!Value.IsArray())
+    {
+        OutError = "Expected array of strings";
+        return false;
+    }
+    for (const SimpleJsonValue& Entry : Value.GetArray())
+    {
+        if (!Entry.IsString())
+        {
+            OutError = "Expected string value in array";
+            return false;
+        }
+        OutStrings.push_back(Entry.AsString());
+    }
+    return true;
+}
+
+bool ExtractListSpecs(const SimpleJsonValue& Value, std::vector<PuzzleListSpec>& OutSpecs, std::string& OutError)
+{
+    if (!Value.IsArray())
+    {
+        OutError = "Expected array for list definitions";
+        return false;
+    }
+    for (const SimpleJsonValue& Entry : Value.GetArray())
+    {
+        if (!Entry.IsObject())
+        {
+            OutError = "List definition must be an object";
+            return false;
+        }
+        const SimpleJsonValue* IndexValue = Entry.Find("index");
+        const SimpleJsonValue* ValuesValue = Entry.Find("values");
+        if (IndexValue == nullptr || !IndexValue->IsNumber())
+        {
+            OutError = "List definition missing numeric 'index'";
+            return false;
+        }
+        if (ValuesValue == nullptr || !ValuesValue->IsArray())
+        {
+            OutError = "List definition missing array 'values'";
+            return false;
+        }
+        PuzzleListSpec Spec;
+        Spec.Index = IndexValue->AsInt();
+        for (const SimpleJsonValue& Number : ValuesValue->GetArray())
+        {
+            if (!Number.IsNumber())
+            {
+                OutError = "List values must be numeric";
+                return false;
+            }
+            Spec.Values.push_back(Number.AsInt());
+        }
+        OutSpecs.push_back(Spec);
+    }
+    return true;
+}
+
+bool ExtractRegisterMap(const SimpleJsonValue& Value, std::unordered_map<std::string, int>& OutRegisters, std::string& OutError)
+{
+    if (!Value.IsObject())
+    {
+        OutError = "Register block must be an object";
+        return false;
+    }
+    for (const auto& Pair : Value.GetObject())
+    {
+        if (!Pair.second.IsNumber())
+        {
+            OutError = "Register values must be numeric";
+            return false;
+        }
+        OutRegisters[ToUpper(Pair.first)] = Pair.second.AsInt();
+    }
+    return true;
+}
+
+const SimpleJsonValue* FindFirstOf(const SimpleJsonValue& Object, std::initializer_list<const char*> Keys)
+{
+    for (const char* Key : Keys)
+    {
+        if (const SimpleJsonValue* Value = Object.Find(Key))
+        {
+            return Value;
+        }
+    }
+    return nullptr;
+}
+}
+
+std::optional<int> ParseRegisterName(const std::string& Name)
+{
+    const std::string Upper = ToUpper(Name);
+    if (Upper == "X")
+    {
+        return 0;
+    }
+    if (Upper == "Y")
+    {
+        return 1;
+    }
+    if (Upper == "Z")
+    {
+        return 2;
+    }
+    return std::nullopt;
+}
+
+bool LoadPuzzleFromFile(const std::string& Path, PuzzleData& OutData, std::string& OutError)
+{
+    std::ifstream Input(Path);
+    if (!Input)
+    {
+        OutError = "Failed to open puzzle file: " + Path;
+        return false;
+    }
+    std::ostringstream Buffer;
+    Buffer << Input.rdbuf();
+
+    SimpleJsonValue Root;
+    if (!SimpleJsonValue::Parse(Buffer.str(), Root, OutError))
+    {
+        return false;
+    }
+    if (!Root.IsObject())
+    {
+        OutError = "Puzzle file must start with a JSON object";
+        return false;
+    }
+
+    OutData = PuzzleData{};
+    if (const SimpleJsonValue* Title = Root.Find("title"))
+    {
+        if (!Title->IsString())
+        {
+            OutError = "Puzzle title must be a string";
+            return false;
+        }
+        OutData.Title = Title->AsString();
+    }
+    else
+    {
+        OutData.Title = "Untitled Puzzle";
+    }
+
+    if (const SimpleJsonValue* Description = Root.Find("description"))
+    {
+        if (!Description->IsString())
+        {
+            OutError = "Puzzle description must be a string";
+            return false;
+        }
+        OutData.Description = Description->AsString();
+    }
+
+    if (const SimpleJsonValue* Starter = FindFirstOf(Root, {"starter", "starterCode", "naiveSolution"}))
+    {
+        if (!ExtractStringArray(*Starter, OutData.StarterCode, OutError))
+        {
+            return false;
+        }
+    }
+
+    if (OutData.StarterCode.empty())
+    {
+        OutData.StarterCode = {"RET"};
+    }
+
+    if (const SimpleJsonValue* HistoryBlock = Root.Find("history"))
+    {
+        if (!HistoryBlock->IsArray())
+        {
+            OutError = "History must be an array";
+            return false;
+        }
+        for (const SimpleJsonValue& Entry : HistoryBlock->GetArray())
+        {
+            if (!Entry.IsObject())
+            {
+                OutError = "History entries must be objects";
+                return false;
+            }
+            const SimpleJsonValue* Label = Entry.Find("label");
+            const SimpleJsonValue* Cycles = Entry.Find("cycles");
+            if (Label == nullptr || !Label->IsString() || Cycles == nullptr || !Cycles->IsNumber())
+            {
+                OutError = "History entries require 'label' and numeric 'cycles'";
+                return false;
+            }
+            PuzzleHistoryEntry HistoryEntry;
+            HistoryEntry.Label = Label->AsString();
+            HistoryEntry.Cycles = Cycles->AsInt();
+            OutData.History.push_back(HistoryEntry);
+        }
+    }
+
+    const SimpleJsonValue* Tests = Root.Find("tests");
+    if (Tests == nullptr || !Tests->IsArray())
+    {
+        OutError = "Puzzle requires an array of tests";
+        return false;
+    }
+
+    for (const SimpleJsonValue& TestValue : Tests->GetArray())
+    {
+        if (!TestValue.IsObject())
+        {
+            OutError = "Test entries must be objects";
+            return false;
+        }
+        PuzzleTestCase Test;
+        if (const SimpleJsonValue* NameValue = TestValue.Find("name"))
+        {
+            if (!NameValue->IsString())
+            {
+                OutError = "Test name must be a string";
+                return false;
+            }
+            Test.Name = NameValue->AsString();
+        }
+        else
+        {
+            Test.Name = "Unnamed Test";
+        }
+
+        if (const SimpleJsonValue* Registers = TestValue.Find("registers"))
+        {
+            if (!ExtractRegisterMap(*Registers, Test.InitialRegisters, OutError))
+            {
+                return false;
+            }
+        }
+
+        if (const SimpleJsonValue* Lists = TestValue.Find("lists"))
+        {
+            if (!ExtractListSpecs(*Lists, Test.InitialLists, OutError))
+            {
+                return false;
+            }
+        }
+
+        if (const SimpleJsonValue* ExpectedRegisters = TestValue.Find("expectedRegisters"))
+        {
+            if (!ExtractRegisterMap(*ExpectedRegisters, Test.Expectation.Registers, OutError))
+            {
+                return false;
+            }
+        }
+
+        if (const SimpleJsonValue* ExpectedLists = TestValue.Find("expectedLists"))
+        {
+            if (!ExtractListSpecs(*ExpectedLists, Test.Expectation.Lists, OutError))
+            {
+                return false;
+            }
+        }
+
+        OutData.Tests.push_back(Test);
+    }
+
+    if (OutData.Tests.empty())
+    {
+        OutError = "Puzzle must define at least one test";
+        return false;
+    }
+
+    return true;
+}
+

--- a/TestApp/Puzzle.h
+++ b/TestApp/Puzzle.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "SimpleJson.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct PuzzleListSpec
+{
+    int Index = 0;
+    std::vector<int> Values;
+};
+
+struct PuzzleExpectation
+{
+    std::unordered_map<std::string, int> Registers;
+    std::vector<PuzzleListSpec> Lists;
+
+    bool HasExpectations() const
+    {
+        return !Registers.empty() || !Lists.empty();
+    }
+};
+
+struct PuzzleTestCase
+{
+    std::string Name;
+    std::unordered_map<std::string, int> InitialRegisters;
+    std::vector<PuzzleListSpec> InitialLists;
+    PuzzleExpectation Expectation;
+};
+
+struct PuzzleHistoryEntry
+{
+    std::string Label;
+    int Cycles = 0;
+};
+
+struct PuzzleData
+{
+    std::string Title;
+    std::string Description;
+    std::vector<std::string> StarterCode;
+    std::vector<PuzzleTestCase> Tests;
+    std::vector<PuzzleHistoryEntry> History;
+};
+
+bool LoadPuzzleFromFile(const std::string& Path, PuzzleData& OutData, std::string& OutError);
+
+std::optional<int> ParseRegisterName(const std::string& Name);
+

--- a/TestApp/SimpleJson.cpp
+++ b/TestApp/SimpleJson.cpp
@@ -1,0 +1,523 @@
+#include "SimpleJson.h"
+
+#include <cctype>
+#include <sstream>
+
+namespace
+{
+class SimpleJsonParser
+{
+public:
+    explicit SimpleJsonParser(const std::string& InText)
+        : Text(InText)
+    {
+    }
+
+    bool Parse(SimpleJsonValue& OutValue)
+    {
+        SkipWhitespace();
+        if (!ParseValue(OutValue))
+        {
+            return false;
+        }
+        SkipWhitespace();
+        if (!IsAtEnd())
+        {
+            ErrorMessage = "Unexpected trailing characters";
+            return false;
+        }
+        return true;
+    }
+
+    const std::string& GetError() const
+    {
+        return ErrorMessage;
+    }
+
+private:
+    bool IsAtEnd() const
+    {
+        return Index >= Text.size();
+    }
+
+    char Peek() const
+    {
+        return IsAtEnd() ? '\0' : Text[Index];
+    }
+
+    char Consume()
+    {
+        return IsAtEnd() ? '\0' : Text[Index++];
+    }
+
+    void SkipWhitespace()
+    {
+        while (!IsAtEnd())
+        {
+            const char Ch = Peek();
+            if (Ch == ' ' || Ch == '\t' || Ch == '\n' || Ch == '\r')
+            {
+                ++Index;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    bool Match(const char Expected)
+    {
+        if (Peek() == Expected)
+        {
+            ++Index;
+            return true;
+        }
+        return false;
+    }
+
+    bool ParseValue(SimpleJsonValue& OutValue)
+    {
+        if (IsAtEnd())
+        {
+            ErrorMessage = "Unexpected end of input";
+            return false;
+        }
+        const char Ch = Peek();
+        if (Ch == 'n')
+        {
+            return ParseNull(OutValue);
+        }
+        if (Ch == 't' || Ch == 'f')
+        {
+            return ParseBool(OutValue);
+        }
+        if (Ch == '"')
+        {
+            return ParseString(OutValue);
+        }
+        if (Ch == '[')
+        {
+            return ParseArray(OutValue);
+        }
+        if (Ch == '{')
+        {
+            return ParseObject(OutValue);
+        }
+        return ParseNumber(OutValue);
+    }
+
+    bool ParseNull(SimpleJsonValue& OutValue)
+    {
+        if (Text.compare(Index, 4, "null") != 0)
+        {
+            ErrorMessage = "Invalid token, expected 'null'";
+            return false;
+        }
+        Index += 4;
+        OutValue.SetNull();
+        return true;
+    }
+
+    bool ParseBool(SimpleJsonValue& OutValue)
+    {
+        if (Text.compare(Index, 4, "true") == 0)
+        {
+            Index += 4;
+            OutValue.SetBool(true);
+            return true;
+        }
+        if (Text.compare(Index, 5, "false") == 0)
+        {
+            Index += 5;
+            OutValue.SetBool(false);
+            return true;
+        }
+        ErrorMessage = "Invalid boolean literal";
+        return false;
+    }
+
+    bool ParseString(SimpleJsonValue& OutValue)
+    {
+        if (!Match('"'))
+        {
+            ErrorMessage = "Expected opening quote for string";
+            return false;
+        }
+        std::string Value;
+        while (!IsAtEnd())
+        {
+            const char Ch = Consume();
+            if (Ch == '"')
+            {
+                OutValue.SetString(Value);
+                return true;
+            }
+            if (Ch == '\\')
+            {
+                if (!ParseEscape(Value))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                Value.push_back(Ch);
+            }
+        }
+        ErrorMessage = "Unterminated string";
+        return false;
+    }
+
+    bool ParseEscape(std::string& OutValue)
+    {
+        if (IsAtEnd())
+        {
+            ErrorMessage = "Unterminated escape sequence";
+            return false;
+        }
+        const char Escaped = Consume();
+        switch (Escaped)
+        {
+        case '"': OutValue.push_back('"'); return true;
+        case '\\': OutValue.push_back('\\'); return true;
+        case '/': OutValue.push_back('/'); return true;
+        case 'b': OutValue.push_back('\b'); return true;
+        case 'f': OutValue.push_back('\f'); return true;
+        case 'n': OutValue.push_back('\n'); return true;
+        case 'r': OutValue.push_back('\r'); return true;
+        case 't': OutValue.push_back('\t'); return true;
+        case 'u':
+            return ParseUnicodeEscape(OutValue);
+        default:
+            ErrorMessage = "Unsupported escape sequence";
+            return false;
+        }
+    }
+
+    bool ParseUnicodeEscape(std::string& OutValue)
+    {
+        if (Index + 4 > Text.size())
+        {
+            ErrorMessage = "Invalid unicode escape";
+            return false;
+        }
+        int CodePoint = 0;
+        for (int i = 0; i < 4; ++i)
+        {
+            const char Ch = Text[Index + i];
+            if (!std::isxdigit(static_cast<unsigned char>(Ch)))
+            {
+                ErrorMessage = "Invalid unicode escape";
+                return false;
+            }
+            CodePoint <<= 4;
+            if (Ch >= '0' && Ch <= '9')
+            {
+                CodePoint += Ch - '0';
+            }
+            else if (Ch >= 'a' && Ch <= 'f')
+            {
+                CodePoint += 10 + (Ch - 'a');
+            }
+            else
+            {
+                CodePoint += 10 + (Ch - 'A');
+            }
+        }
+        Index += 4;
+        if (CodePoint <= 0x7F)
+        {
+            OutValue.push_back(static_cast<char>(CodePoint));
+        }
+        else
+        {
+            std::ostringstream Oss;
+            Oss << "\\u" << std::hex << CodePoint;
+            OutValue += Oss.str();
+        }
+        return true;
+    }
+
+    bool ParseNumber(SimpleJsonValue& OutValue)
+    {
+        const size_t Start = Index;
+        if (Peek() == '-')
+        {
+            ++Index;
+        }
+        if (!std::isdigit(static_cast<unsigned char>(Peek())))
+        {
+            ErrorMessage = "Invalid number literal";
+            return false;
+        }
+        if (Peek() == '0')
+        {
+            ++Index;
+        }
+        else
+        {
+            while (std::isdigit(static_cast<unsigned char>(Peek())))
+            {
+                ++Index;
+            }
+        }
+
+        if (Peek() == '.')
+        {
+            ++Index;
+            if (!std::isdigit(static_cast<unsigned char>(Peek())))
+            {
+                ErrorMessage = "Invalid fractional literal";
+                return false;
+            }
+            while (std::isdigit(static_cast<unsigned char>(Peek())))
+            {
+                ++Index;
+            }
+        }
+
+        if (Peek() == 'e' || Peek() == 'E')
+        {
+            ++Index;
+            if (Peek() == '+' || Peek() == '-')
+            {
+                ++Index;
+            }
+            if (!std::isdigit(static_cast<unsigned char>(Peek())))
+            {
+                ErrorMessage = "Invalid exponent";
+                return false;
+            }
+            while (std::isdigit(static_cast<unsigned char>(Peek())))
+            {
+                ++Index;
+            }
+        }
+
+        const std::string NumberLiteral = Text.substr(Start, Index - Start);
+        try
+        {
+            const double Value = std::stod(NumberLiteral);
+            OutValue.SetNumber(Value);
+            return true;
+        }
+        catch (...)
+        {
+            ErrorMessage = "Failed to parse number";
+            return false;
+        }
+    }
+
+    bool ParseArray(SimpleJsonValue& OutValue)
+    {
+        if (!Match('['))
+        {
+            ErrorMessage = "Expected '['";
+            return false;
+        }
+        SimpleJsonValue::Array Elements;
+        SkipWhitespace();
+        if (Match(']'))
+        {
+            OutValue.SetArray(std::move(Elements));
+            return true;
+        }
+        while (true)
+        {
+            SimpleJsonValue Element;
+            if (!ParseValue(Element))
+            {
+                return false;
+            }
+            Elements.push_back(Element);
+            SkipWhitespace();
+            if (Match(']'))
+            {
+                OutValue.SetArray(std::move(Elements));
+                return true;
+            }
+            if (!Match(','))
+            {
+                ErrorMessage = "Expected ',' or ']'";
+                return false;
+            }
+            SkipWhitespace();
+        }
+    }
+
+    bool ParseObject(SimpleJsonValue& OutValue)
+    {
+        if (!Match('{'))
+        {
+            ErrorMessage = "Expected '{'";
+            return false;
+        }
+        SimpleJsonValue::Object Members;
+        SkipWhitespace();
+        if (Match('}'))
+        {
+            OutValue.SetObject(std::move(Members));
+            return true;
+        }
+        while (true)
+        {
+            SimpleJsonValue KeyValue;
+            if (!ParseString(KeyValue))
+            {
+                return false;
+            }
+            SkipWhitespace();
+            if (!Match(':'))
+            {
+                ErrorMessage = "Expected ':' after key";
+                return false;
+            }
+            SkipWhitespace();
+            SimpleJsonValue Value;
+            if (!ParseValue(Value))
+            {
+                return false;
+            }
+            Members[KeyValue.AsString()] = Value;
+            SkipWhitespace();
+            if (Match('}'))
+            {
+                OutValue.SetObject(std::move(Members));
+                return true;
+            }
+            if (!Match(','))
+            {
+                ErrorMessage = "Expected ',' or '}'";
+                return false;
+            }
+            SkipWhitespace();
+        }
+    }
+
+    const std::string& Text;
+    size_t Index = 0;
+    std::string ErrorMessage;
+};
+}
+
+SimpleJsonValue::SimpleJsonValue()
+    : ValueType(Type::Null)
+    , BoolValue(false)
+    , NumberValue(0.0)
+{
+}
+
+bool SimpleJsonValue::AsBool(const bool Default) const
+{
+    return IsBool() ? BoolValue : Default;
+}
+
+double SimpleJsonValue::AsNumber(const double Default) const
+{
+    return IsNumber() ? NumberValue : Default;
+}
+
+int SimpleJsonValue::AsInt(const int Default) const
+{
+    return static_cast<int>(AsNumber(static_cast<double>(Default)));
+}
+
+std::string SimpleJsonValue::AsString(const std::string& Default) const
+{
+    return IsString() ? StringValue : Default;
+}
+
+SimpleJsonValue::Array& SimpleJsonValue::GetArray()
+{
+    return ArrayValue;
+}
+
+const SimpleJsonValue::Array& SimpleJsonValue::GetArray() const
+{
+    static Array Empty;
+    return IsArray() ? ArrayValue : Empty;
+}
+
+SimpleJsonValue::Object& SimpleJsonValue::GetObject()
+{
+    return ObjectValue;
+}
+
+const SimpleJsonValue::Object& SimpleJsonValue::GetObject() const
+{
+    static Object Empty;
+    return IsObject() ? ObjectValue : Empty;
+}
+
+const SimpleJsonValue* SimpleJsonValue::Find(const std::string& Key) const
+{
+    if (!IsObject())
+    {
+        return nullptr;
+    }
+    const auto It = ObjectValue.find(Key);
+    return It != ObjectValue.end() ? &It->second : nullptr;
+}
+
+SimpleJsonValue* SimpleJsonValue::Find(const std::string& Key)
+{
+    if (!IsObject())
+    {
+        return nullptr;
+    }
+    auto It = ObjectValue.find(Key);
+    return It != ObjectValue.end() ? &It->second : nullptr;
+}
+
+bool SimpleJsonValue::Parse(const std::string& Text, SimpleJsonValue& OutValue, std::string& OutError)
+{
+    SimpleJsonParser Parser(Text);
+    if (!Parser.Parse(OutValue))
+    {
+        OutError = Parser.GetError();
+        return false;
+    }
+    return true;
+}
+
+void SimpleJsonValue::SetNull()
+{
+    ValueType = Type::Null;
+    BoolValue = false;
+    NumberValue = 0.0;
+    StringValue.clear();
+    ArrayValue.clear();
+    ObjectValue.clear();
+}
+
+void SimpleJsonValue::SetBool(const bool bValue)
+{
+    ValueType = Type::Boolean;
+    BoolValue = bValue;
+}
+
+void SimpleJsonValue::SetNumber(const double Number)
+{
+    ValueType = Type::Number;
+    NumberValue = Number;
+}
+
+void SimpleJsonValue::SetString(std::string Value)
+{
+    ValueType = Type::String;
+    StringValue = std::move(Value);
+}
+
+void SimpleJsonValue::SetArray(Array&& Values)
+{
+    ValueType = Type::Array;
+    ArrayValue = std::move(Values);
+}
+
+void SimpleJsonValue::SetObject(Object&& Members)
+{
+    ValueType = Type::Object;
+    ObjectValue = std::move(Members);
+}
+

--- a/TestApp/SimpleJson.h
+++ b/TestApp/SimpleJson.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+class SimpleJsonValue
+{
+public:
+    enum class Type
+    {
+        Null,
+        Boolean,
+        Number,
+        String,
+        Array,
+        Object
+    };
+
+    using Array = std::vector<SimpleJsonValue>;
+    using Object = std::map<std::string, SimpleJsonValue>;
+
+    SimpleJsonValue();
+
+    Type GetType() const { return ValueType; }
+    bool IsNull() const { return ValueType == Type::Null; }
+    bool IsBool() const { return ValueType == Type::Boolean; }
+    bool IsNumber() const { return ValueType == Type::Number; }
+    bool IsString() const { return ValueType == Type::String; }
+    bool IsArray() const { return ValueType == Type::Array; }
+    bool IsObject() const { return ValueType == Type::Object; }
+
+    bool AsBool(bool Default = false) const;
+    double AsNumber(double Default = 0.0) const;
+    int AsInt(int Default = 0) const;
+    std::string AsString(const std::string& Default = "") const;
+
+    Array& GetArray();
+    const Array& GetArray() const;
+
+    Object& GetObject();
+    const Object& GetObject() const;
+
+    const SimpleJsonValue* Find(const std::string& Key) const;
+    SimpleJsonValue* Find(const std::string& Key);
+
+    static bool Parse(const std::string& Text, SimpleJsonValue& OutValue, std::string& OutError);
+
+    void SetNull();
+    void SetBool(bool bValue);
+    void SetNumber(double Number);
+    void SetString(std::string Value);
+    void SetArray(Array&& Values);
+    void SetObject(Object&& Members);
+
+private:
+    Type ValueType;
+    bool BoolValue;
+    double NumberValue;
+    std::string StringValue;
+    Array ArrayValue;
+    Object ObjectValue;
+};
+

--- a/TestApp/TestApp.cpp
+++ b/TestApp/TestApp.cpp
@@ -1,48 +1,543 @@
+#include "Puzzle.h"
+
 #include "../src/Conchpiler/parser.h"
+#include "../src/Conchpiler/thread.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
-#include <string>
-#include <vector>
+#include <iterator>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <unordered_map>
+
+namespace
+{
+std::string Trim(const std::string& Text)
+{
+    const auto First = std::find_if_not(Text.begin(), Text.end(), [](unsigned char Ch) { return std::isspace(Ch); });
+    const auto Last = std::find_if_not(Text.rbegin(), Text.rend(), [](unsigned char Ch) { return std::isspace(Ch); }).base();
+    if (First >= Last)
+    {
+        return std::string();
+    }
+    return std::string(First, Last);
+}
+
+std::string PromptLine(const std::string& Message)
+{
+    std::cout << Message;
+    std::string Line;
+    std::getline(std::cin, Line);
+    return Line;
+}
+
+std::string RegisterName(size_t Index)
+{
+    static const char* Names[] = {"X", "Y", "Z"};
+    if (Index < std::size(Names))
+    {
+        return Names[Index];
+    }
+    return "R" + std::to_string(Index);
+}
+
+std::string FormatListValues(const std::vector<int>& Values)
+{
+    std::ostringstream Oss;
+    Oss << "[";
+    for (size_t i = 0; i < Values.size(); ++i)
+    {
+        if (i > 0)
+        {
+            Oss << ", ";
+        }
+        Oss << Values[i];
+    }
+    Oss << "]";
+    return Oss.str();
+}
+
+std::vector<std::pair<std::string, int>> SortRegisterMap(const std::unordered_map<std::string, int>& Registers)
+{
+    std::vector<std::pair<std::string, int>> Sorted(Registers.begin(), Registers.end());
+    std::sort(Sorted.begin(), Sorted.end(), [](const auto& A, const auto& B)
+    {
+        return A.first < B.first;
+    });
+    return Sorted;
+}
+
+void ShowPuzzleOverview(const PuzzleData& Puzzle)
+{
+    std::cout << "=== " << Puzzle.Title << " ===\n";
+    if (!Puzzle.Description.empty())
+    {
+        std::cout << Puzzle.Description << "\n";
+    }
+    std::cout << "\nTests:" << std::endl;
+    for (size_t i = 0; i < Puzzle.Tests.size(); ++i)
+    {
+        const PuzzleTestCase& Test = Puzzle.Tests[i];
+        std::cout << "  " << (i + 1) << ". " << Test.Name << std::endl;
+        if (!Test.InitialRegisters.empty())
+        {
+            std::cout << "     Registers:";
+            for (const auto& Pair : SortRegisterMap(Test.InitialRegisters))
+            {
+                std::cout << " " << Pair.first << "=" << Pair.second;
+            }
+            std::cout << std::endl;
+        }
+        if (!Test.InitialLists.empty())
+        {
+            std::cout << "     Lists:";
+            for (const PuzzleListSpec& Spec : Test.InitialLists)
+            {
+                std::cout << " LIST" << Spec.Index << "=" << FormatListValues(Spec.Values);
+            }
+            std::cout << std::endl;
+        }
+        if (Test.Expectation.HasExpectations())
+        {
+            std::cout << "     Expectations:";
+            for (const auto& Pair : SortRegisterMap(Test.Expectation.Registers))
+            {
+                std::cout << " " << Pair.first << "=" << Pair.second;
+            }
+            for (const PuzzleListSpec& Spec : Test.Expectation.Lists)
+            {
+                std::cout << " LIST" << Spec.Index << "=" << FormatListValues(Spec.Values);
+            }
+            std::cout << std::endl;
+        }
+    }
+    if (!Puzzle.History.empty())
+    {
+        std::cout << "\nCycle history:" << std::endl;
+        for (const PuzzleHistoryEntry& Entry : Puzzle.History)
+        {
+            std::cout << "  " << std::setw(4) << Entry.Cycles << " cycles - " << Entry.Label << std::endl;
+        }
+    }
+    std::cout << std::endl;
+}
+
+void ShowCode(const std::vector<std::string>& Code)
+{
+    std::cout << "Current program (" << Code.size() << " line" << (Code.size() == 1 ? "" : "s") << "):\n";
+    for (size_t i = 0; i < Code.size(); ++i)
+    {
+        std::cout << std::setw(3) << (i + 1) << " | " << Code[i] << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+bool LoadCodeFromFile(const std::string& Path, std::vector<std::string>& OutCode, std::string& OutError)
+{
+    std::ifstream Input(Path);
+    if (!Input)
+    {
+        OutError = "Unable to open file: " + Path;
+        return false;
+    }
+    std::vector<std::string> Lines;
+    std::string Line;
+    while (std::getline(Input, Line))
+    {
+        Lines.push_back(Line);
+    }
+    OutCode = std::move(Lines);
+    return true;
+}
+
+bool SaveCodeToFile(const std::string& Path, const std::vector<std::string>& Code, std::string& OutError)
+{
+    std::ofstream Output(Path);
+    if (!Output)
+    {
+        OutError = "Unable to write to file: " + Path;
+        return false;
+    }
+    for (size_t i = 0; i < Code.size(); ++i)
+    {
+        Output << Code[i];
+        if (i + 1 < Code.size())
+        {
+            Output << '\n';
+        }
+    }
+    return true;
+}
+
+void EditCode(std::vector<std::string>& Code)
+{
+    std::cout << "Enter new program lines. Type '.done' on a blank line to finish." << std::endl;
+    std::vector<std::string> NewCode;
+    while (true)
+    {
+        std::string Line;
+        std::getline(std::cin, Line);
+        if (!std::cin)
+        {
+            break;
+        }
+        const std::string Trimmed = Trim(Line);
+        if (Trimmed == ".done")
+        {
+            break;
+        }
+        NewCode.push_back(Line);
+    }
+    if (!NewCode.empty())
+    {
+        Code = std::move(NewCode);
+    }
+}
+
+bool ApplyTestSetup(const PuzzleTestCase& Test, ConThread& Thread, std::vector<std::string>& Messages)
+{
+    bool bSuccess = true;
+    for (const auto& Pair : Test.InitialRegisters)
+    {
+        const std::optional<int> IndexOpt = ParseRegisterName(Pair.first);
+        if (!IndexOpt)
+        {
+            Messages.push_back("Unknown register '" + Pair.first + "'");
+            bSuccess = false;
+            continue;
+        }
+        Thread.SetThreadValue(static_cast<size_t>(*IndexOpt), Pair.second);
+    }
+    for (const PuzzleListSpec& Spec : Test.InitialLists)
+    {
+        ConVariableList* List = Thread.GetListVar(static_cast<size_t>(Spec.Index));
+        if (List == nullptr)
+        {
+            Messages.push_back("LIST" + std::to_string(Spec.Index) + " is not defined in this program");
+            bSuccess = false;
+            continue;
+        }
+        List->SetValues(Spec.Values);
+        List->Reset();
+    }
+    return bSuccess;
+}
+
+std::vector<std::string> ValidateExpectations(const PuzzleExpectation& Expectation, const ConThread& Thread)
+{
+    std::vector<std::string> Issues;
+    for (const auto& Pair : Expectation.Registers)
+    {
+        const std::optional<int> IndexOpt = ParseRegisterName(Pair.first);
+        if (!IndexOpt)
+        {
+            Issues.push_back("Expectation references unknown register '" + Pair.first + "'");
+            continue;
+        }
+        const int Actual = Thread.GetThreadValue(static_cast<size_t>(*IndexOpt));
+        if (Actual != Pair.second)
+        {
+            Issues.push_back("Expected " + Pair.first + "=" + std::to_string(Pair.second) + ", got " + std::to_string(Actual));
+        }
+    }
+    for (const PuzzleListSpec& Spec : Expectation.Lists)
+    {
+        const ConVariableList* List = Thread.GetListVar(static_cast<size_t>(Spec.Index));
+        if (List == nullptr)
+        {
+            Issues.push_back("Expectation references undefined LIST" + std::to_string(Spec.Index));
+            continue;
+        }
+        const std::vector<int32>& Actual = List->GetValues();
+        const std::vector<int> ActualCopy(Actual.begin(), Actual.end());
+        if (Actual.size() != Spec.Values.size() || !std::equal(Actual.begin(), Actual.end(), Spec.Values.begin()))
+        {
+            Issues.push_back("Expected LIST" + std::to_string(Spec.Index) + "=" + FormatListValues(Spec.Values) + ", got " + FormatListValues(ActualCopy));
+        }
+    }
+    return Issues;
+}
+
+std::optional<int> ComputeStaticCycleCount(const std::vector<std::string>& Code, std::vector<std::string>& Errors)
+{
+    ConParser Parser;
+    ConThread Thread;
+    if (!Parser.Parse(Code, Thread))
+    {
+        Errors = Parser.GetErrors();
+        return std::nullopt;
+    }
+    Thread.SetTraceEnabled(false);
+    Thread.UpdateCycleCount();
+    return Thread.GetCycleCount();
+}
+
+void PrintThreadState(const ConThread& Thread)
+{
+    std::cout << "    Registers:";
+    for (size_t i = 0; i < Thread.GetThreadVarCount(); ++i)
+    {
+        std::cout << " " << RegisterName(i) << "=" << Thread.GetThreadValue(i) << " (C=" << Thread.GetThreadCacheValue(i) << ")";
+    }
+    std::cout << std::endl;
+    if (Thread.GetListVarCount() > 0)
+    {
+        std::cout << "    Lists:";
+        for (size_t i = 0; i < Thread.GetListVarCount(); ++i)
+        {
+            const ConVariableList* List = Thread.GetListVar(i);
+            if (List != nullptr)
+            {
+                const std::vector<int32>& Values = List->GetValues();
+                std::vector<int> Copy(Values.begin(), Values.end());
+                std::cout << " LIST" << i << "=" << FormatListValues(Copy);
+            }
+        }
+        std::cout << std::endl;
+    }
+}
+
+void RunTests(const PuzzleData& Puzzle, const std::vector<std::string>& Code)
+{
+    if (Code.empty())
+    {
+        std::cout << "No code to execute. Use the editor or load a file first.\n";
+        return;
+    }
+
+    std::vector<std::string> ParseErrors;
+    std::optional<int> StaticCycles = ComputeStaticCycleCount(Code, ParseErrors);
+    if (!StaticCycles)
+    {
+        std::cout << "Syntax errors detected:\n";
+        for (const std::string& Error : ParseErrors)
+        {
+            std::cout << "  " << Error << std::endl;
+        }
+        return;
+    }
+
+    std::cout << "Static cycle estimate: " << *StaticCycles << std::endl;
+    if (!Puzzle.History.empty())
+    {
+        const auto Best = std::min_element(Puzzle.History.begin(), Puzzle.History.end(), [](const PuzzleHistoryEntry& A, const PuzzleHistoryEntry& B)
+        {
+            return A.Cycles < B.Cycles;
+        });
+        if (Best != Puzzle.History.end())
+        {
+            if (*StaticCycles < Best->Cycles)
+            {
+                std::cout << "You are on track to beat the recorded best of " << Best->Cycles << " cycles (" << Best->Label << ")!" << std::endl;
+            }
+            else if (*StaticCycles == Best->Cycles)
+            {
+                std::cout << "Matched the best recorded cycle count of " << Best->Cycles << " (" << Best->Label << ")." << std::endl;
+            }
+            else
+            {
+                std::cout << "Need " << (*StaticCycles - Best->Cycles) << " fewer cycles to beat the best record (" << Best->Label << ")." << std::endl;
+            }
+        }
+    }
+    std::cout << std::endl;
+
+    bool bAllPassed = true;
+
+    for (size_t TestIndex = 0; TestIndex < Puzzle.Tests.size(); ++TestIndex)
+    {
+        const PuzzleTestCase& Test = Puzzle.Tests[TestIndex];
+        std::cout << "Running test " << (TestIndex + 1) << "/" << Puzzle.Tests.size() << ": " << Test.Name << std::endl;
+
+        ConParser Parser;
+        ConThread Thread;
+        if (!Parser.Parse(Code, Thread))
+        {
+            std::cout << "  Parse failed during execution.\n";
+            for (const std::string& Error : Parser.GetErrors())
+            {
+                std::cout << "    " << Error << std::endl;
+            }
+            bAllPassed = false;
+            continue;
+        }
+
+        Thread.SetTraceEnabled(false);
+        Thread.UpdateCycleCount();
+
+        std::vector<std::string> SetupMessages;
+        if (!ApplyTestSetup(Test, Thread, SetupMessages))
+        {
+            std::cout << "  Test setup failed:" << std::endl;
+            for (const std::string& Message : SetupMessages)
+            {
+                std::cout << "    " << Message << std::endl;
+            }
+            bAllPassed = false;
+            continue;
+        }
+
+        Thread.Execute();
+        if (Thread.HadRuntimeError())
+        {
+            std::cout << "  Runtime error:" << std::endl;
+            for (const std::string& Error : Thread.GetRuntimeErrors())
+            {
+                std::cout << "    " << Error << std::endl;
+            }
+            bAllPassed = false;
+            continue;
+        }
+
+        const std::vector<std::string> ExpectationIssues = ValidateExpectations(Test.Expectation, Thread);
+        if (!ExpectationIssues.empty())
+        {
+            std::cout << "  Expectation mismatch:" << std::endl;
+            for (const std::string& Issue : ExpectationIssues)
+            {
+                std::cout << "    " << Issue << std::endl;
+            }
+            bAllPassed = false;
+        }
+        else
+        {
+            std::cout << "  Test passed." << std::endl;
+        }
+
+        PrintThreadState(Thread);
+        std::cout << std::endl;
+    }
+
+    if (bAllPassed)
+    {
+        std::cout << "All tests passed. Tweak inline ops and cache usage to chase even fewer cycles!" << std::endl;
+    }
+    else
+    {
+        std::cout << "Some tests failed. Use the diagnostics above to adjust your strategy." << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+void PrintMenu()
+{
+    std::cout << "Menu:\n"
+              << "  1) Show puzzle overview\n"
+              << "  2) Show current code\n"
+              << "  3) Edit code\n"
+              << "  4) Load code from file\n"
+              << "  5) Save code to file\n"
+              << "  6) Run tests\n"
+              << "  7) Quit\n";
+}
+
+int ReadMenuChoice()
+{
+    while (true)
+    {
+        std::string Line = PromptLine("Select option: ");
+        std::stringstream Stream(Line);
+        int Choice = 0;
+        if (Stream >> Choice)
+        {
+            return Choice;
+        }
+        std::cout << "Invalid selection. Please enter a number from the menu." << std::endl;
+    }
+}
+}
 
 int main(int Argc, char* Argv[])
 {
-    ConParser Parser;
-    std::vector<std::string> Lines = {
-        "SET X 10",
-        "SET Y 10",
-        "ADD X Y",
-        "SUB Y 15",
-        "SET Z MUL Y -2",
-        "IF GTR X Y",
-        "   ADD X Y",
-        "LOOP GTR X 0",
-        "   DECR X",
-        "   REDO",
-        "SWP X",
-        "SET X SUB Z 2"
-    };
-    ConThread Thread;
-    const bool bParsed = Parser.Parse(Lines, Thread);
-    if (!bParsed)
+    if (Argc < 2)
     {
-        std::cout << "Failed to parse program:\n";
-        for (const std::string& Error : Parser.GetErrors())
-        {
-            std::cout << "  " << Error << std::endl;
-        }
+        std::cout << "Usage: conch_ide <puzzle.json> [optional_code_file]\n";
         return 1;
     }
 
-    Thread.UpdateCycleCount();
-    Thread.Execute();
-    if (Thread.HadRuntimeError())
+    const std::string PuzzlePath = Argv[1];
+    PuzzleData Puzzle;
+    std::string Error;
+    if (!LoadPuzzleFromFile(PuzzlePath, Puzzle, Error))
     {
-        std::cout << "Runtime error(s) encountered:\n";
-        for (const std::string& Error : Thread.GetRuntimeErrors())
-        {
-            std::cout << "  " << Error << std::endl;
-        }
+        std::cout << "Failed to load puzzle: " << Error << std::endl;
         return 1;
     }
-    std::cout << "Total cycles: " << Thread.GetCycleCount() << std::endl;
+
+    std::vector<std::string> Code = Puzzle.StarterCode;
+    if (Argc >= 3)
+    {
+        if (!LoadCodeFromFile(Argv[2], Code, Error))
+        {
+            std::cout << "Warning: " << Error << "\nUsing starter code instead." << std::endl;
+            Code = Puzzle.StarterCode;
+        }
+    }
+
+    std::cout << "Loaded puzzle: " << Puzzle.Title << "\n";
+    ShowPuzzleOverview(Puzzle);
+    ShowCode(Code);
+
+    bool bRunning = true;
+    while (bRunning && std::cin)
+    {
+        PrintMenu();
+        const int Choice = ReadMenuChoice();
+        std::cout << std::endl;
+        switch (Choice)
+        {
+        case 1:
+            ShowPuzzleOverview(Puzzle);
+            break;
+        case 2:
+            ShowCode(Code);
+            break;
+        case 3:
+            EditCode(Code);
+            break;
+        case 4:
+        {
+            const std::string Path = PromptLine("File to load: ");
+            if (!LoadCodeFromFile(Path, Code, Error))
+            {
+                std::cout << Error << std::endl;
+            }
+            else
+            {
+                std::cout << "Code loaded from " << Path << "\n";
+            }
+            break;
+        }
+        case 5:
+        {
+            const std::string Path = PromptLine("File to save to: ");
+            if (!SaveCodeToFile(Path, Code, Error))
+            {
+                std::cout << Error << std::endl;
+            }
+            else
+            {
+                std::cout << "Saved code to " << Path << "\n";
+            }
+            break;
+        }
+        case 6:
+            RunTests(Puzzle, Code);
+            break;
+        case 7:
+            bRunning = false;
+            break;
+        default:
+            std::cout << "Unknown option." << std::endl;
+            break;
+        }
+    }
+
+    std::cout << "Good luck reducing those cycles!" << std::endl;
     return 0;
 }
+

--- a/TestApp/TestApp.vcxproj
+++ b/TestApp/TestApp.vcxproj
@@ -154,7 +154,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Puzzle.cpp" />
+    <ClCompile Include="SimpleJson.cpp" />
     <ClCompile Include="TestApp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Puzzle.h" />
+    <ClInclude Include="SimpleJson.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Conchpiler\Conchpiler.vcxproj">

--- a/TestApp/TestApp.vcxproj.filters
+++ b/TestApp/TestApp.vcxproj.filters
@@ -15,8 +15,22 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Puzzle.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SimpleJson.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="TestApp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Puzzle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SimpleJson.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestApp/sample_puzzle.json
+++ b/TestApp/sample_puzzle.json
@@ -1,0 +1,17 @@
+{
+  "title": "Sample Warmup",
+  "description": "Start with something simple: prove your toolchain works by leaving the registers untouched.",
+  "starter": [
+    "SET X 0"
+  ],
+  "tests": [
+    {
+      "name": "Baseline",
+      "registers": {"X": 0, "Y": 0, "Z": 0},
+      "expectedRegisters": {"X": 0, "Y": 0, "Z": 0}
+    }
+  ],
+  "history": [
+    {"label": "Naive", "cycles": 1}
+  ]
+}

--- a/src/Conchpiler/thread.cpp
+++ b/src/Conchpiler/thread.cpp
@@ -20,22 +20,31 @@ void ConThread::Execute()
             case ConLineKind::Ops:
                 Line.Execute();
                 ++i;
-                for (const ConVariableCached* Var : ThreadVariables)
+                if (bTraceExecution)
                 {
-                    cout << Var->GetVal() << ", (" << Var->GetCache() << ") ";
+                    for (const ConVariableCached* Var : ThreadVariables)
+                    {
+                        cout << Var->GetVal() << ", (" << Var->GetCache() << ") ";
+                    }
+                    cout << endl;
                 }
-                cout << endl;
                 break;
             case ConLineKind::If:
                 if (!Line.EvaluateCondition())
                 {
                     i += Line.GetSkipCount() + 1;
-                    cout << "FALSE" << endl;
+                    if (bTraceExecution)
+                    {
+                        cout << "FALSE" << endl;
+                    }
                 }
                 else
                 {
                     ++i;
-                    cout << "TRUE" << endl;
+                    if (bTraceExecution)
+                    {
+                        cout << "TRUE" << endl;
+                    }
                 }
                 break;
             case ConLineKind::Loop:
@@ -170,6 +179,68 @@ void ConThread::SetOwnedStorage(std::vector<std::unique_ptr<ConVariableCached>>&
 void ConThread::ConstructLine(const ConLine &Line)
 {
     Lines.push_back(Line);
+}
+
+void ConThread::SetTraceEnabled(const bool bEnabled)
+{
+    bTraceExecution = bEnabled;
+}
+
+ConVariableCached* ConThread::GetThreadVar(const size_t Index)
+{
+    if (Index >= ThreadVariables.size())
+    {
+        return nullptr;
+    }
+    return ThreadVariables[Index];
+}
+
+const ConVariableCached* ConThread::GetThreadVar(const size_t Index) const
+{
+    if (Index >= ThreadVariables.size())
+    {
+        return nullptr;
+    }
+    return ThreadVariables[Index];
+}
+
+int32 ConThread::GetThreadValue(const size_t Index) const
+{
+    const ConVariableCached* Var = GetThreadVar(Index);
+    return Var != nullptr ? Var->GetVal() : 0;
+}
+
+int32 ConThread::GetThreadCacheValue(const size_t Index) const
+{
+    const ConVariableCached* Var = GetThreadVar(Index);
+    return Var != nullptr ? Var->GetCache() : 0;
+}
+
+void ConThread::SetThreadValue(const size_t Index, const int32 Value)
+{
+    ConVariableCached* Var = GetThreadVar(Index);
+    if (Var != nullptr)
+    {
+        Var->SetVal(Value);
+    }
+}
+
+ConVariableList* ConThread::GetListVar(const size_t Index)
+{
+    if (Index >= OwnedListStorage.size())
+    {
+        return nullptr;
+    }
+    return OwnedListStorage[Index].get();
+}
+
+const ConVariableList* ConThread::GetListVar(const size_t Index) const
+{
+    if (Index >= OwnedListStorage.size())
+    {
+        return nullptr;
+    }
+    return OwnedListStorage[Index].get();
 }
 
 void ConThread::ReportRuntimeError(const ConRuntimeError& Error)

--- a/src/Conchpiler/thread.h
+++ b/src/Conchpiler/thread.h
@@ -22,6 +22,20 @@ public:
     bool HadRuntimeError() const { return bHadRuntimeError; }
     const std::vector<std::string>& GetRuntimeErrors() const { return RuntimeErrors; }
 
+    void SetTraceEnabled(bool bEnabled);
+    bool IsTraceEnabled() const { return bTraceExecution; }
+
+    size_t GetThreadVarCount() const { return ThreadVariables.size(); }
+    ConVariableCached* GetThreadVar(size_t Index);
+    const ConVariableCached* GetThreadVar(size_t Index) const;
+    int32 GetThreadValue(size_t Index) const;
+    int32 GetThreadCacheValue(size_t Index) const;
+    void SetThreadValue(size_t Index, int32 Value);
+
+    size_t GetListVarCount() const { return OwnedListStorage.size(); }
+    ConVariableList* GetListVar(size_t Index);
+    const ConVariableList* GetListVar(size_t Index) const;
+
 private:
     void ReportRuntimeError(const ConRuntimeError& Error);
     void ResetRuntimeErrors();
@@ -34,4 +48,5 @@ private:
     std::vector<std::unique_ptr<ConBaseOp>> OwnedOpStorage;
     std::vector<std::string> RuntimeErrors;
     bool bHadRuntimeError = false;
+    bool bTraceExecution = true;
 };

--- a/src/Conchpiler/variable.cpp
+++ b/src/Conchpiler/variable.cpp
@@ -170,6 +170,16 @@ void ConVariableList::Reset()
     }
 }
 
+const vector<int32>& ConVariableList::GetValues() const
+{
+    return Storage;
+}
+
+size_t ConVariableList::Size() const
+{
+    return Storage.size();
+}
+
 VariableRef::VariableRef(const VariableKind InKind, ConVariable* const InPtr, ConVariableCached* const InOwner)
     : Kind(InKind)
     , Ptr(InPtr)

--- a/src/Conchpiler/variable.h
+++ b/src/Conchpiler/variable.h
@@ -79,6 +79,8 @@ struct ConVariableList : public ConVariable
     void SetValues(const vector<int32>& Values);
     bool Empty() const;
     void Reset();
+    const vector<int32>& GetValues() const;
+    size_t Size() const;
 
 private:
     vector<int32> Storage;


### PR DESCRIPTION
## Summary
- replace the TestApp harness with a console IDE that loads puzzle metadata, edits code, runs tests, and reports cycle counts versus recorded history
- implement a lightweight JSON parser plus puzzle loader utilities and ship a sample puzzle definition for quick smoke tests
- expose thread/list inspection helpers and a trace toggle for the runtime so the IDE can seed data, check expectations, and present clean output, while documenting the workflow in the README

## Testing
- g++ -std=c++17 TestApp/TestApp.cpp TestApp/Puzzle.cpp TestApp/SimpleJson.cpp src/Conchpiler/*.cpp -I src/Conchpiler -I TestApp -o conch_ide
- ./conch_ide TestApp/sample_puzzle.json <<'EOF'
6
7
EOF


------
https://chatgpt.com/codex/tasks/task_e_68d119f55f64832d9bc81bdaabc691fb