### PR TITLE
Remove unused SwapInPlace helper from cached variable

### DIFF
--- a/src/Conchpiler/variable.cpp
+++ b/src/Conchpiler/variable.cpp
@@ -77,14 +77,6 @@ void ConVariableCached::Swap()
     Cache = Temp;
 }
 
-ConVariableCached ConVariableCached::SwapInPlace()
-{
-    const int32 Temp = Val;
-    Val = Cache;
-    Cache = Temp;
-    return *this;
-}
-
 ConVariable* ConVariableCached::GetCacheVariable()
 {
     return &CacheAccessor;

--- a/src/Conchpiler/variable.h
+++ b/src/Conchpiler/variable.h
@@ -42,7 +42,6 @@ struct ConVariableCached : public ConVariable
     void SetCache(int32 NewVal);
     // swaps the value and the cache
     void Swap();
-    ConVariableCached SwapInPlace();
 
     ConVariable* GetCacheVariable();
     const ConVariable* GetCacheVariable() const;


### PR DESCRIPTION
## Summary
- remove the unused `ConVariableCached::SwapInPlace` helper that duplicated `Swap`

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68da26aab6fc832d89282d3d58a0d058